### PR TITLE
Support skipping and clearing idle animation after face enrollment

### DIFF
--- a/src/cozmo/faces.py
+++ b/src/cozmo/faces.py
@@ -163,17 +163,12 @@ class EnrollNamedFace(action.Action):
 
     _action_type = _clad_to_engine_cozmo.RobotActionType.ENROLL_NAMED_FACE
 
-    def __init__(self, face, name, play_anim, **kw):
+    def __init__(self, face, name, **kw):
         super().__init__(**kw)
         #: The face (e.g. an instance of :class:`cozmo.faces.Face`) that will be named.
         self.face = face
         #: The name that is going to be bound to the face.
         self.name = name
-
-        anim_sequence = _clad_to_engine_cozmo.FaceEnrollmentSequence.Simple
-        immediate_sequence = _clad_to_engine_cozmo.FaceEnrollmentSequence.Immediate
-        #: The sequence to play (either plays a face-scanning animation, or nothing)
-        self.sequence = anim_sequence if play_anim else immediate_sequence
 
     def _repr_values(self):
         return "face=%s name=%s" % (self.face, self.name)
@@ -181,7 +176,7 @@ class EnrollNamedFace(action.Action):
     def _encode(self):
         return _clad_to_engine_iface.EnrollNamedFace(faceID=self.face.face_id,
                                                      name=self.name,
-                                                     sequence=self.sequence)
+                                                     sequence=_clad_to_engine_cozmo.FaceEnrollmentSequence.Simple)
 
 
 class Face(event.Dispatcher):
@@ -195,7 +190,7 @@ class Face(event.Dispatcher):
     which face it is looking at.
     '''
 
-    #: callable: The factory function to return an :class:`~cozmo.faces.EnrollNamedFace`
+    #: callable: The factory function to return an :class:`EnrollNamedFace`
     #: class or subclass instance.
     enroll_named_face_factory = EnrollNamedFace
 
@@ -348,20 +343,17 @@ class Face(event.Dispatcher):
 
     #### Commands ####
 
-    def name_face(self, name, play_anim=True):
+    def name_face(self, name):
         '''Assign a name to this face. Cozmo will remember this name between SDK runs.
 
         Args:
             name (string): The name that will be assigned to this face
-            play_anim (bool): True plays a scanning animation,
-                False to enroll immediately with no animation sequence
         Returns:
             An instance of :class:`cozmo.faces.EnrollNamedFace` action object
         '''
         logger.info("Sending enroll named face request for face=%s and name=%s", self, name)
-        action = self.enroll_named_face_factory(face=self, name=name,
-                            play_anim=play_anim, conn=self.conn,
-                            robot=self._robot, dispatch_parent=self)
+        action = self.enroll_named_face_factory(face=self, name=name, conn=self.conn,
+                                                robot=self._robot, dispatch_parent=self)
         self._robot._action_dispatcher._send_single_action(action)
         return action
 

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -934,11 +934,15 @@ class Robot(event.Dispatcher):
     def set_idle_animation(self, anim_trigger):
         '''Set the Idle Animation on Cozmo
 
+        Idle animations behave the same as regular animations except that they
+        loop forever on Cozmo regardless of what actions and animations
+        are being played.
+
         Args:
             anim_trigger (:class:`cozmo.anim.Triggers`): The animation trigger to set
-                Note: :attr:`cozmo.anim.Triggers.Count` will clear all idle animations
+                Note: :attr:`cozmo.anim.Triggers.Count` will clear all idle animations.
         Raises:
-            :class:`ValueError` if supplied an invalid idle_animation trigger.
+            :class:`ValueError` if supplied an invalid animation trigger.
         '''
         if not isinstance(anim_trigger, anim._AnimTrigger):
             raise TypeError("Invalid anim_trigger supplied")

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -931,6 +931,26 @@ class Robot(event.Dispatcher):
         self._action_dispatcher._send_single_action(action)
         return action
 
+    def set_idle_animation(self, anim_trigger):
+        '''Set the Idle Animation on Cozmo
+
+        Args:
+            anim_trigger (:class:`cozmo.anim.Triggers`): The animation trigger to set
+                Note: :attr:`cozmo.anim.Triggers.Count` will clear all idle animations
+        Raises:
+            :class:`ValueError` if supplied an invalid idle_animation trigger.
+        '''
+        if not isinstance(anim_trigger, anim._AnimTrigger):
+            raise TypeError("Invalid anim_trigger supplied")
+
+        msg = _clad_to_engine_iface.SetIdleAnimation(robotID=self.robot_id,
+                                                     animTrigger=anim_trigger.id)
+        self.conn.send_msg(msg)
+
+    def clear_idle_animation(self):
+        '''Clears any Idle Animation currently playing on Cozmo'''
+        self.set_idle_animation(anim.Triggers.Count)
+
     # Cozmo's Face animation commands
 
     def display_lcd_face_image(self, screen_data, duration_ms):


### PR DESCRIPTION
Doing Face.name_face with the default sequence leaves an idle animation looping on Cozmo, so:
a) Allow that to be skipped (via passing in play_anim=False)
b) Allow idle animation to be set/cleared afterwards

Fixed a couple of existing issues with EnrollNamedFace docstrings being incorrectly generated