### PR TITLE
Correct code references from LCD to OLED

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -16,7 +16,7 @@ The API
     cozmo.event
     cozmo.exceptions
     cozmo.faces
-    cozmo.lcd_face
+    cozmo.oled_face
     cozmo.lights
     cozmo.objects
     cozmo.robot

--- a/examples/alarm_clock.py
+++ b/examples/alarm_clock.py
@@ -56,7 +56,7 @@ def make_text_image(text_to_draw, x, y, font=None):
     '''
 
     # make a blank image for the text, initialized to opaque black
-    text_image = Image.new('RGBA', cozmo.lcd_face.dimensions(), (0, 0, 0, 255))
+    text_image = Image.new('RGBA', cozmo.oled_face.dimensions(), (0, 0, 0, 255))
 
     # get a drawing context
     dc = ImageDraw.Draw(text_image)
@@ -130,14 +130,14 @@ def make_clock_image(current_time):
         return make_text_image(time_text, 8, 6, _clock_font)
 
     # make a blank image for the text, initialized to opaque black
-    clock_image = Image.new('RGBA', cozmo.lcd_face.dimensions(), (0, 0, 0, 255))
+    clock_image = Image.new('RGBA', cozmo.oled_face.dimensions(), (0, 0, 0, 255))
 
     # get a drawing context
     dc = ImageDraw.Draw(clock_image)
 
     # calculate position of clock elements
     text_height = 9
-    screen_width, screen_height = cozmo.lcd_face.dimensions()
+    screen_width, screen_height = cozmo.oled_face.dimensions()
     analog_width = screen_width
     analog_height = screen_height - text_height
     cen_x = analog_width * 0.5
@@ -298,10 +298,10 @@ def alarm_clock(robot):
             if (last_displayed_time is None) or (current_time.second != last_displayed_time.second):
                 # Create the updated image with this time
                 clock_image = make_clock_image(current_time)
-                lcd_face_data = cozmo.lcd_face.convert_image_to_screen_data(clock_image)
+                oled_face_data = cozmo.oled_face.convert_image_to_screen_data(clock_image)
 
                 # display for 1 second
-                robot.display_lcd_face_image(lcd_face_data, 1000.0)
+                robot.display_oled_face_image(oled_face_data, 1000.0)
                 last_displayed_time = current_time
 
         # only sleep for a fraction of a second to ensure we update the seconds as soon as they change

--- a/examples/cozmo_face_image.py
+++ b/examples/cozmo_face_image.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-'''Display images on Cozmo's face (lcd screen)
+'''Display images on Cozmo's face (oled screen)
 '''
 
 import sys
@@ -45,10 +45,10 @@ def run(sdk_conn):
         image = Image.open(image_name)
 
         # resize to fit on Cozmo's face screen
-        resized_image = image.resize(cozmo.lcd_face.dimensions(), resampling_mode)
+        resized_image = image.resize(cozmo.oled_face.dimensions(), resampling_mode)
 
-        # convert the image to the format used by the lcd screen
-        face_image = cozmo.lcd_face.convert_image_to_screen_data(resized_image,
+        # convert the image to the format used by the oled screen
+        face_image = cozmo.oled_face.convert_image_to_screen_data(resized_image,
                                                                  invert_image=True)
         face_images.append(face_image)
 
@@ -61,7 +61,7 @@ def run(sdk_conn):
 
     for _ in range(num_loops):
         for image in face_images:
-            robot.display_lcd_face_image(image, duration_s * 1000.0)
+            robot.display_oled_face_image(image, duration_s * 1000.0)
             time.sleep(duration_s)
 
 

--- a/src/cozmo/__init__.py
+++ b/src/cozmo/__init__.py
@@ -29,7 +29,7 @@ from . import behavior
 from . import conn
 from . import event
 from . import exceptions
-from . import lcd_face
+from . import oled_face
 from . import lights
 from . import objects
 from . import robot
@@ -45,5 +45,5 @@ from .version import __version__, __cozmoclad_version__
 
 __all__ = ['logger', 'logger_protocol'] + \
     ['action', 'anim', 'annotate', 'behavior', 'conn', 'event', 'exceptions'] + \
-    ['lcd_face', 'lights', 'objects', 'robot', 'run', 'util', 'world'] + \
+    ['oled_face', 'lights', 'objects', 'robot', 'run', 'util', 'world'] + \
         (run.__all__ + exceptions.__all__)

--- a/src/cozmo/oled_face.py
+++ b/src/cozmo/oled_face.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-''' Cozmo's LCD-screen that displays his face - related functions and values.
+''' Cozmo's OLED screen that displays his face - related functions and values.
 '''
 
 # __all__ should order by constants, event classes, other classes, functions.
@@ -26,7 +26,7 @@ SCREEN_HEIGHT = SCREEN_HALF_HEIGHT * 2
 
 
 def dimensions():
-    '''Return the dimension (width, height) of the lcd screen.
+    '''Return the dimension (width, height) of the oled screen.
 
     Note: The screen is displayed interlaced, with only every other line displayed
     This alternates every time the image is changed (no longer than 30 seconds)

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -933,13 +933,13 @@ class Robot(event.Dispatcher):
 
     # Cozmo's Face animation commands
 
-    def display_lcd_face_image(self, screen_data, duration_ms):
-        ''' Display a bitmap image on Cozmo's LCD face screen.
+    def display_oled_face_image(self, screen_data, duration_ms):
+        ''' Display a bitmap image on Cozmo's OLED face screen.
 
         Args:
             screen_data (:class:`bytes`): a sequence of pixels (8 pixels per
                 byte) (from e.g.
-                :func:`cozmo.lcd_face.convert_pixels_to_screen_data`).
+                :func:`cozmo.oled_face.convert_pixels_to_screen_data`).
             duration_ms (float): time to keep displaying this image on Cozmo's
                 face (clamped to 30 seconds in engine).
         '''


### PR DESCRIPTION
Correct code references from LCD to OLED:
* rename cozmo.lcd_face to cozmo.oled_face
* rename robot.display_lcd_face_image to robot.display_oled_face_image
* change LCD to OLED in comments

This is a (hopefully unusual) backwards-incompatible change.