### PR TITLE
Added Charger object support to SDK

### DIFF
--- a/examples/drive_to_charger_test.py
+++ b/examples/drive_to_charger_test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2016 Anki, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the file LICENSE.txt or at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''Make Cozmo drive towards his charger.
+
+The script shows an example of accessing the charger object from
+Cozmo's world, and driving towards it.
+'''
+
+import asyncio
+import sys
+import time
+
+import cozmo
+from cozmo.util import degrees, distance_mm, speed_mmps
+
+
+def find_charger(robot):
+    '''The core of the follow_faces program'''
+
+    # If the robot was on the charger, drive them forward and clear of the charger
+    if robot.is_on_charger:
+        # drive off the charger
+        robot.drive_off_charger_contacts().wait_for_completed()
+        robot.drive_straight(distance_mm(100), speed_mmps(50)).wait_for_completed()
+        # Start moving the lift down
+        robot.move_lift(-3)
+        # turn around to look at the charger
+        robot.turn_in_place(degrees(180)).wait_for_completed()
+        # Tilt the head to be level
+        robot.set_head_angle(degrees(0)).wait_for_completed()
+        # wait half a second to ensure Cozmo has seen the charger
+        time.sleep(0.5)
+        # drive backwards away from the charger
+        robot.drive_straight(distance_mm(-60), speed_mmps(50)).wait_for_completed()
+
+    # try to find the charger
+    charger = robot.world.charger
+
+    if charger:
+        if charger.pose.origin_id == robot.pose.origin_id:
+            print("Cozmo already knows where the charger is!")
+        else:
+            # Cozmo knows about the charger, but the pose is not based on the
+            # same origin as the robot (e.g. the robot was moved since seeing
+            # the charger) so try to look for the charger first
+            charger = None
+
+    if not charger:
+        # Tell Cozmo to look around for the charger
+        look_around = robot.start_behavior(cozmo.behavior.BehaviorTypes.LookAroundInPlace)
+        try:
+            charger = robot.world.wait_for_observed_charger(timeout=30)
+            print("Found charger: %s" % charger)
+        except asyncio.TimeoutError:
+            print("Didn't see the charger")
+        finally:
+            # whether we find it or not, we want to stop the behavior
+            look_around.stop()
+
+    if not charger:
+        charger = robot.world.charger
+        if charger:
+            if charger.pose.origin_id == robot.pose.origin_id:
+                print("Cozmo now knows where the charger is!")
+            else:
+                print("Attempting to drive to last known location of the charger")
+
+    if charger:
+        # Attempt to drive near to the charger, and then stop.
+        action = robot.go_to_object(charger, distance_mm(65.0))
+        action.wait_for_completed()
+        print("Completed action: result = %s" % action)
+        print("Done.")
+
+
+def run(sdk_conn):
+    '''The run method runs once the Cozmo SDK is connected.'''
+    robot = sdk_conn.wait_for_robot()
+
+    try:
+        find_charger(robot)
+
+    except KeyboardInterrupt:
+        print("")
+        print("Exit requested by user")
+
+
+if __name__ == '__main__':
+    cozmo.setup_basic_logging()
+    cozmo.robot.Robot.drive_off_charger_on_connect = False  # Cozmo can stay on charger for now
+    try:
+        cozmo.connect_with_tkviewer(run, force_on_top=True)
+    except cozmo.ConnectionError as e:
+        sys.exit("A connection error occurred: %s" % e)

--- a/examples/drive_to_charger_test.py
+++ b/examples/drive_to_charger_test.py
@@ -28,8 +28,8 @@ import cozmo
 from cozmo.util import degrees, distance_mm, speed_mmps
 
 
-def find_charger(robot):
-    '''The core of the follow_faces program'''
+def drive_to_charger(robot):
+    '''The core of the drive_to_charger program'''
 
     # If the robot was on the charger, drive them forward and clear of the charger
     if robot.is_on_charger:
@@ -48,16 +48,18 @@ def find_charger(robot):
         robot.drive_straight(distance_mm(-60), speed_mmps(50)).wait_for_completed()
 
     # try to find the charger
-    charger = robot.world.charger
+    charger = None
 
-    if charger:
-        if charger.pose.origin_id == robot.pose.origin_id:
+    # see if Cozmo already knows where the charger is
+    if robot.world.charger:
+        if robot.world.charger.pose.origin_id == robot.pose.origin_id:
             print("Cozmo already knows where the charger is!")
+            charger = robot.world.charger
         else:
             # Cozmo knows about the charger, but the pose is not based on the
             # same origin as the robot (e.g. the robot was moved since seeing
             # the charger) so try to look for the charger first
-            charger = None
+            pass
 
     if not charger:
         # Tell Cozmo to look around for the charger
@@ -70,14 +72,6 @@ def find_charger(robot):
         finally:
             # whether we find it or not, we want to stop the behavior
             look_around.stop()
-
-    if not charger:
-        charger = robot.world.charger
-        if charger:
-            if charger.pose.origin_id == robot.pose.origin_id:
-                print("Cozmo now knows where the charger is!")
-            else:
-                print("Attempting to drive to last known location of the charger")
 
     if charger:
         # Attempt to drive near to the charger, and then stop.
@@ -92,7 +86,7 @@ def run(sdk_conn):
     robot = sdk_conn.wait_for_robot()
 
     try:
-        find_charger(robot)
+        drive_to_charger(robot)
 
     except KeyboardInterrupt:
         print("")

--- a/examples/go_to_object_test.py
+++ b/examples/go_to_object_test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2016 Anki, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the file LICENSE.txt or at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''Tell Cozmo to find a cube, and then drive up to it
+
+This is a test / example usage of the robot.go_to_object call which creates a
+GoToObject action, that can be used to drive within a given distance of an
+object (e.g. a LightCube).
+'''
+
+import asyncio
+import sys
+
+import cozmo
+from cozmo.util import degrees, distance_mm
+
+
+def go_to_object_test(robot):
+    '''The core of the go to object test program'''
+
+    # Move lift down and tilt the head up
+    robot.move_lift(-3)
+    robot.set_head_angle(degrees(0)).wait_for_completed()
+
+    # look around and try to find a cube
+    look_around = robot.start_behavior(cozmo.behavior.BehaviorTypes.LookAroundInPlace)
+
+    cube = None
+
+    try:
+        cube = robot.world.wait_for_observed_light_cube(timeout=30)
+        print("Found cube: %s" % cube)
+    except asyncio.TimeoutError:
+        print("Didn't find a cube")
+    finally:
+        # whether we find it or not, we want to stop the behavior
+        look_around.stop()
+
+    if cube:
+        # Drive to 70mm away from the cube (much closer and Cozmo
+        # will likely hit the cube) and then stop.
+        action = robot.go_to_object(cube, distance_mm(70.0))
+        action.wait_for_completed()
+        print("Completed action: result = %s" % action)
+        print("Done.")
+
+
+def run(sdk_conn):
+    '''The run method runs once Cozmo is connected.'''
+    robot = sdk_conn.wait_for_robot()
+
+    try:
+        go_to_object_test(robot)
+
+    except KeyboardInterrupt:
+        print("")
+        print("Exit requested by user")
+
+if __name__ == '__main__':
+    cozmo.setup_basic_logging()
+    try:
+        cozmo.connect(run)
+    except cozmo.ConnectionError as e:
+        sys.exit("A connection error occurred: %s" % e)

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -38,8 +38,8 @@ online documentation.  They will be detected as :class:`CustomObject` instances.
 
 # __all__ should order by constants, event classes, other classes, functions.
 __all__ = ['OBJECT_VISIBILITY_TIMEOUT',
-           'EvtObjectTapped', 'EvtObjectAppeared', 'EvtObjectConnectChanged',
-           'EvtObjectDisappeared', 'EvtObjectObserved',
+           'EvtObjectTapped', 'EvtObjectAppeared', 'EvtObjectAvailable',
+           'EvtObjectConnectChanged', 'EvtObjectDisappeared', 'EvtObjectObserved',
            'ObservableObject', 'LightCube', 'CustomObject', 'FixedCustomObject']
 
 
@@ -92,6 +92,17 @@ class EvtObjectAppeared(event.Event):
     obj = 'The object that was observed'
     updated = 'A set of field names that have changed'
     image_box = 'A comzo.util.ImageBox defining where the object is within Cozmo\'s camera view'
+    pose = 'The cozmo.util.Pose defining the position and rotation of the object.'
+
+
+class EvtObjectAvailable(event.Event):
+    '''Triggered when the engine reports that an object is available (i.e. exists)
+
+    This will usually occur at the start of the program in response to the SDK
+    sending RequestAvailableObjects to the engine.
+    '''
+    obj = 'The object that is available'
+    updated = 'A set of field names that have changed'
     pose = 'The cozmo.util.Pose defining the position and rotation of the object.'
 
 
@@ -186,6 +197,28 @@ class ObservableObject(event.Dispatcher):
         self._is_visible = False
         self.dispatch_event(EvtObjectDisappeared, obj=self)
 
+    def _handle_available_object(self, available_object):
+        # triggered when engine sends available objects
+        # as a response to a RequestAvailableObjects message
+        if self.last_observed_robot_timestamp and \
+                (self.last_observed_robot_timestamp > available_object.lastObservedTimestamp):
+            logger.debug("ignoring old available_object=%s obj=%s (last_observed_robot_timestamp=%s)",
+                         available_object, self, self.last_observed_robot_timestamp)
+            return
+
+        changed_fields = {'last_observed_robot_timestamp', 'pose'}
+
+        self.last_observed_robot_timestamp = available_object.lastObservedTimestamp
+
+        self._pose = util.Pose(available_object.pose.x, available_object.pose.y, available_object.pose.z,
+                               q0=available_object.pose.q0, q1=available_object.pose.q1,
+                               q2=available_object.pose.q2, q3=available_object.pose.q3,
+                               origin_id=available_object.pose.originID)
+
+        self.dispatch_event(EvtObjectAvailable,
+                            obj=self,
+                            updated=changed_fields,
+                            pose = self._pose)
 
     #### Properties ####
 
@@ -364,6 +397,12 @@ class LightCube(ObservableObject):
         '''Turn off all the lights on the cube.'''
         self.set_lights(lights.off_light)
 
+
+class Charger(ObservableObject):
+    '''Cozmo's charger object, can be seen and driven towards'''
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
 
 
 class CustomObject(ObservableObject):

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -40,7 +40,8 @@ online documentation.  They will be detected as :class:`CustomObject` instances.
 __all__ = ['OBJECT_VISIBILITY_TIMEOUT',
            'EvtObjectTapped', 'EvtObjectAppeared', 'EvtObjectAvailable',
            'EvtObjectConnectChanged', 'EvtObjectDisappeared', 'EvtObjectObserved',
-           'ObservableObject', 'LightCube', 'CustomObject', 'FixedCustomObject']
+           'ObservableObject', 'LightCube', 'Charger', 'CustomObject',
+           'FixedCustomObject']
 
 
 import collections

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -74,7 +74,7 @@ class EvtObjectObserved(event.Event):
     obj = 'The object that was observed'
     updated = 'A set of field names that have changed'
     image_box = 'A comzo.util.ImageBox defining where the object is within Cozmo\'s camera view'
-    pose = 'The cozmo.util.Pose defining the position and rotation of the object.'
+    pose = 'The cozmo.util.Pose defining the position and rotation of the object'
 
 
 class EvtObjectAppeared(event.Event):
@@ -92,18 +92,18 @@ class EvtObjectAppeared(event.Event):
     obj = 'The object that was observed'
     updated = 'A set of field names that have changed'
     image_box = 'A comzo.util.ImageBox defining where the object is within Cozmo\'s camera view'
-    pose = 'The cozmo.util.Pose defining the position and rotation of the object.'
+    pose = 'The cozmo.util.Pose defining the position and rotation of the object'
 
 
 class EvtObjectAvailable(event.Event):
-    '''Triggered when the engine reports that an object is available (i.e. exists)
+    '''Triggered when the engine reports that an object is available (i.e. exists).
 
     This will usually occur at the start of the program in response to the SDK
     sending RequestAvailableObjects to the engine.
     '''
     obj = 'The object that is available'
     updated = 'A set of field names that have changed'
-    pose = 'The cozmo.util.Pose defining the position and rotation of the object.'
+    pose = 'The cozmo.util.Pose defining the position and rotation of the object'
 
 
 class EvtObjectDisappeared(event.Event):
@@ -200,8 +200,8 @@ class ObservableObject(event.Dispatcher):
     def _handle_available_object(self, available_object):
         # triggered when engine sends available objects
         # as a response to a RequestAvailableObjects message
-        if self.last_observed_robot_timestamp and \
-                (self.last_observed_robot_timestamp > available_object.lastObservedTimestamp):
+        if (self.last_observed_robot_timestamp and
+                (self.last_observed_robot_timestamp > available_object.lastObservedTimestamp)):
             logger.debug("ignoring old available_object=%s obj=%s (last_observed_robot_timestamp=%s)",
                          available_object, self, self.last_observed_robot_timestamp)
             return
@@ -218,7 +218,7 @@ class ObservableObject(event.Dispatcher):
         self.dispatch_event(EvtObjectAvailable,
                             obj=self,
                             updated=changed_fields,
-                            pose = self._pose)
+                            pose=self._pose)
 
     #### Properties ####
 
@@ -399,7 +399,7 @@ class LightCube(ObservableObject):
 
 
 class Charger(ObservableObject):
-    '''Cozmo's charger object, can be seen and driven towards'''
+    '''Cozmo's charger object, which the robot can observe and drive toward.'''
 
     def __init__(self, *a, **kw):
         super().__init__(*a, **kw)

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -1172,23 +1172,23 @@ class Robot(event.Dispatcher):
         self._action_dispatcher._send_single_action(action)
         return action
 
-    def go_to_object(self, object, distance_from_object):
+    def go_to_object(self, target_object, distance_from_object):
         '''Tells Cozmo to drive to the specified object.
 
         Args:
-            object (:class:`cozmo.objects.ObservableObject`): The destination object.
-            distance_from_object (:class:`cozmo.util.Distance`): The distance from
-                the object to stop at - this is the distance between the origins so
-                e.g. from between Cozmo's 2 front wheels to the center of a cube
-                is ~40mm
+            target_object (:class:`cozmo.objects.ObservableObject`): The destination object.
+            distance_from_object (:class:`cozmo.util.Distance`): The distance from the
+                object to stop. This is the distance between the origins. For instance,
+                the distance from the robot's origin (between Cozmo's two front wheels)
+                to the cube's origin (at the center of the cube) is ~40mm.
         Returns:
             A :class:`cozmo.robot.GoToObject` action object which can be queried
                 to see when it is complete.
         '''
-        if not isinstance(object, objects.ObservableObject):
-            raise TypeError("Invalid charger supplied")
+        if not isinstance(target_object, objects.ObservableObject):
+            raise TypeError("Target must be an observable object")
 
-        action = self.go_to_object_factory(object_id=object.object_id,
+        action = self.go_to_object_factory(object_id=target_object.object_id,
                                            distance_from_object=distance_from_object,
                                            conn=self.conn, robot=self, dispatch_parent=self)
         self._action_dispatcher._send_single_action(action)

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -460,7 +460,7 @@ class Robot(event.Dispatcher):
     drive_off_charger_contacts_factory = DriveOffChargerContacts
 
     #: callable: The factory function that returns a
-    #: :class: :class:`DriveStraight` class or subclass instance.
+    #: :class:`DriveStraight` class or subclass instance.
     drive_straight_factory = DriveStraight
 
     # other factories


### PR DESCRIPTION
Added charger factory and object
Added docsstrings for factory objects in world.py
Send RequestAvailableObjects on robot initialize - and handle AvailableObjects message that is returned, this gives us info on connected cubes at the start instead of having to wait to visually see them.
Upgraded "Tap event received for unknown object ID" back to a warning as we should always know about that cube now
Fixed robot.py factory docstrings (they were missing a colon before class)
Made robot keep track of it's origin_id for poses
Added GoToObject support for driving to within X mm of a cube or charger
Added go_to_object_test.py example that shows usage of GoToObject action for finding a cube and driving up to it
Added drive_to_charger_test.py example that shows usage of accessing the charger and driving near to it.