### PR TITLE
Allow SDK connection if CLAD and major.minor version matches

### DIFF
--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -308,13 +308,13 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
                 if cozmoclad.__build_version__ < msg.buildVersion:
                     # App is newer
                     logger.warning(
-                        'Your App is newer than your SDK: '
-                        'We recommend that you upgrade by calling command: '
-                        '"pip3 install --user --ignore-installed cozmo" '
+                        'Your app is newer than your SDK: '
+                        'We recommend that you upgrade your SDK by calling: '
+                        '"pip3 install --user --upgrade cozmo" '
                         'and downloading the latest examples from http://cozmosdk.anki.com/docs/downloads.html')
                 else:
                     logger.warning(
-                        'Your App is older than your SDK: '
+                        'Your app is older than your SDK: '
                         'We recommend that you download the latest app from the app store.')
 
         if clad_hashes_match and build_versions_match:
@@ -343,14 +343,14 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
                 pass
 
             if not build_versions_match:
-                logger.warning('Build versions do not match (cozmoclad version %s != App version %s) - connection refused',
+                logger.warning('Build versions do not match (cozmoclad version %s != app version %s) - connection refused',
                                 cozmoclad.__build_version__, msg.buildVersion)
 
                 if cozmoclad.__build_version__ < msg.buildVersion:
                     # App is newer
                     logger.error(
                         'Please update your SDK to the newest version by calling command: '
-                        '"pip3 install --user --ignore-installed cozmo" '
+                        '"pip3 install --user --upgrade cozmo" '
                         'and downloading the latest examples from http://cozmosdk.anki.com/docs/downloads.html')
                 else:
                     # SDK is newer

--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -299,6 +299,24 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
         build_versions_match = (cozmoclad.__build_version__ == '00000.00000.00000'
             or cozmoclad.__build_version__ == msg.buildVersion)
 
+        if clad_hashes_match and not build_versions_match:
+            # If CLAD hashes match, and this is only a minor version change, allow connection but recommend user upgrades
+            sdk_major_version = cozmoclad.__build_version__.split(".")[0:2]
+            build_major_version = msg.buildVersion.split(".")[0:2]
+            build_versions_match = (sdk_major_version == build_major_version)
+            if build_versions_match:
+                if cozmoclad.__build_version__ < msg.buildVersion:
+                    # App is newer
+                    logger.warning(
+                        'Your App is newer than your SDK: '
+                        'We recommend that you upgrade by calling command: '
+                        '"pip3 install --user --ignore-installed cozmo" '
+                        'and downloading the latest examples from http://cozmosdk.anki.com/docs/downloads.html')
+                else:
+                    logger.warning(
+                        'Your App is older than your SDK: '
+                        'We recommend that you download the latest app from the app store.')
+
         if clad_hashes_match and build_versions_match:
             connection_success_msg = _clad_to_engine_iface.UiDeviceConnectionSuccess(
                 connectionType=msg.connectionType,
@@ -332,7 +350,8 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
                     # App is newer
                     logger.error(
                         'Please update your SDK to the newest version by calling command: '
-                        '"pip3 install --user --ignore-installed cozmo"')
+                        '"pip3 install --user --ignore-installed cozmo" '
+                        'and downloading the latest examples from http://cozmosdk.anki.com/docs/downloads.html')
                 else:
                     # SDK is newer
                     logger.error("Please update your app to the most recent version on the app store.")


### PR DESCRIPTION
On CLAD match but version mismatch, check if the major.minor still match (i.e. this is just a patch version change) and if so allow it, but warn user that they should upgrade app or SDK as appropriate.
Added link to the downloads and suggestion that they should download the latest examples when upgrading the SDK.