### PR TITLE
COZMO-6586 Include already visible objects/faces

### DIFF
--- a/examples/cube_stack.py
+++ b/examples/cube_stack.py
@@ -41,12 +41,14 @@ def run(sdk_conn):
         current_action = robot.pickup_object(cubes[0])
         current_action.wait_for_completed()
         if current_action.failed:
-            print("Pickup Cube failed: code=%s reason=%s" % current_action.failure_reason)
+            code, reason = current_action.failure_reason
+            print("Pickup Cube failed: code=%s reason=%s" % (code, reason))
 
         current_action = robot.place_on_object(cubes[1])
         current_action.wait_for_completed()
         if current_action.failed:
-            print("Place On Cube failed: code=%s reason=%s" % current_action.failure_reason)
+            code, reason = current_action.failure_reason
+            print("Place On Cube failed: code=%s reason=%s" % (code, reason))
 
 if __name__ == '__main__':
     cozmo.setup_basic_logging()

--- a/examples/cube_stack.py
+++ b/examples/cube_stack.py
@@ -38,8 +38,15 @@ def run(sdk_conn):
     if len(cubes) < 2:
         print("Error: need 2 Cubes but only found", len(cubes), "Cube(s)")
     else:
-        robot.pickup_object(cubes[0]).wait_for_completed()
-        robot.place_on_object(cubes[1]).wait_for_completed()
+        current_action = robot.pickup_object(cubes[0])
+        current_action.wait_for_completed()
+        if current_action.failed:
+            print("Pickup Cube failed: code=%s reason=%s" % current_action.failure_reason)
+
+        current_action = robot.place_on_object(cubes[1])
+        current_action.wait_for_completed()
+        if current_action.failed:
+            print("Place On Cube failed: code=%s reason=%s" % current_action.failure_reason)
 
 if __name__ == '__main__':
     cozmo.setup_basic_logging()

--- a/src/cozmo/action.py
+++ b/src/cozmo/action.py
@@ -148,12 +148,12 @@ class Action(event.Dispatcher):
         return self._state in (ACTION_SUCCEEDED, ACTION_FAILED)
 
     @property
-    def succeeded(self):
+    def has_succeeded(self):
         '''bool: True if the action has succeeded.'''
         return self._state == ACTION_SUCCEEDED
 
     @property
-    def failed(self):
+    def has_failed(self):
         '''bool: True if the action has failed.'''
         return self._state == ACTION_FAILED
 

--- a/src/cozmo/action.py
+++ b/src/cozmo/action.py
@@ -100,6 +100,8 @@ class Action(event.Dispatcher):
         extra = self._repr_values()
         if len(extra) > 0:
             extra = ' '+extra
+        if self._state == ACTION_FAILED:
+            extra += " failure_reason=%s failure_code=%s" % (self._failure_reason, self._failure_code)
         return '<%s state=%s%s>' % (self.__class__.__name__, self.state, extra)
 
     def _repr_values(self):
@@ -144,6 +146,16 @@ class Action(event.Dispatcher):
     def is_completed(self):
         '''bool: True if the action has completed (either succeeded or failed).'''
         return self._state in (ACTION_SUCCEEDED, ACTION_FAILED)
+
+    @property
+    def succeeded(self):
+        '''bool: True if the action has succeeded.'''
+        return self._state == ACTION_SUCCEEDED
+
+    @property
+    def failed(self):
+        '''bool: True if the action has failed.'''
+        return self._state == ACTION_FAILED
 
     @property
     def failure_reason(self):

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -170,8 +170,8 @@ class ObservableObject(event.Dispatcher):
         if len(extra) > 0:
             extra = ' '+extra
 
-        return '<%s is_visible=%s pose=%s%s>' % (self.__class__.__name__,
-                self.is_visible, self.pose, extra)
+        return '<%s id=%s is_visible=%s pose=%s%s>' % (self.__class__.__name__,
+                self._object_id, self.is_visible, self.pose, extra)
 
     def _repr_values(self):
         return ''

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -170,7 +170,7 @@ class ObservableObject(event.Dispatcher):
         if len(extra) > 0:
             extra = ' '+extra
 
-        return '<%s id=%s is_visible=%s pose=%s%s>' % (self.__class__.__name__,
+        return '<%s object_id=%s is_visible=%s pose=%s%s>' % (self.__class__.__name__,
                 self._object_id, self.is_visible, self.pose, extra)
 
     def _repr_values(self):

--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -350,23 +350,18 @@ class World(event.Dispatcher):
                 return visible_object
         return None
 
-    def _find_visible_face(self):
-        for visible_face in self.visible_faces:
-            return visible_face
-        return None
-
-    async def wait_for_observed_light_cube(self, timeout=None, include_already_visible=True):
+    async def wait_for_observed_light_cube(self, timeout=None, include_existing=True):
         '''Waits for one of the light cubes to be observed by the robot.
 
         Args:
             timeout (float): Number of seconds to wait for a cube to be
                 observed, or None for indefinite
-            include_already_visible (bool): whether or not to include light cubes
+            include_existing (bool): Specifies whether to include light cubes
                 that are already visible.
         Returns:
             The :class:`cozmo.objects.LightCube` object that was observed.
         '''
-        if include_already_visible:
+        if include_existing:
             obj = self._find_visible_object(objects.LightCube)
             if obj:
                 return obj
@@ -376,19 +371,19 @@ class World(event.Dispatcher):
         evt = await self.wait_for(filter, timeout=timeout)
         return evt.obj
 
-    async def wait_for_observed_face(self, timeout=None, include_already_visible=True):
+    async def wait_for_observed_face(self, timeout=None, include_existing=True):
         '''Waits for a face to be observed by the robot.
 
         Args:
             timeout (float): Number of seconds to wait for a face to be
                 observed, or None for indefinite
-            include_already_visible (bool): whether or not to include faces
+            include_existing (bool): Specifies whether to include faces
                 that are already visible.
         Returns:
             The :class:`cozmo.faces.Face` object that was observed.
         '''
-        if include_already_visible:
-            face = self._find_visible_face()
+        if include_existing:
+            face = next(self.visible_faces, None)
             if face:
                 return face
 
@@ -396,18 +391,18 @@ class World(event.Dispatcher):
         evt = await self.wait_for(filter, timeout=timeout)
         return evt.face
 
-    async def wait_for_observed_charger(self, timeout=None, include_already_visible=True):
+    async def wait_for_observed_charger(self, timeout=None, include_existing=True):
         '''Waits for a charger to be observed by the robot.
 
         Args:
             timeout (float): Number of seconds to wait for a charger to be
                 observed, or None for indefinite
-            include_already_visible (bool): whether or not to include chargers
+            include_existing (bool): Specifies whether to include chargers
                 that are already visible.
         Returns:
             The :class:`cozmo.objects.Charger` object that was observed.
         '''
-        if include_already_visible:
+        if include_existing:
             obj = self._find_visible_object(objects.Charger)
             if obj:
                 return obj
@@ -418,7 +413,7 @@ class World(event.Dispatcher):
         return evt.obj
 
     async def wait_until_observe_num_objects(self, num, object_type=None, timeout=None,
-                                             include_already_visible=True):
+                                             include_existing=True):
         '''Waits for a certain number of unique objects to be seen at least once.
 
         This method waits for a number of unique objects to be seen, but not
@@ -435,7 +430,7 @@ class World(event.Dispatcher):
                 this will cause only the selected object types to be counted.
             timeout (float): Maximum amount of time in seconds to wait for the
                 requested number of objects to be observed.
-            include_already_visible (bool): whether or not to include objects
+            include_existing (bool): Specifies whether to include objects
                 that are already visible.
         Returns:
             A list of length <= num of the unique objects
@@ -451,7 +446,7 @@ class World(event.Dispatcher):
 
         objs_seen = set()
         # If requested, add any objects that can already be seen (they won't create observed events)
-        if include_already_visible:
+        if include_existing:
             for visible_object in self.visible_objects:
                 if (object_type is None) or isinstance(visible_object, object_type):
                     objs_seen.add(visible_object)

--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -348,10 +348,12 @@ class World(event.Dispatcher):
         for visible_object in self.visible_objects:
             if (object_type is None) or isinstance(visible_object, object_type):
                 return visible_object
+        return None
 
     def _find_visible_face(self):
         for visible_face in self.visible_faces:
             return visible_face
+        return None
 
     async def wait_for_observed_light_cube(self, timeout=None, include_already_visible=True):
         '''Waits for one of the light cubes to be observed by the robot.


### PR DESCRIPTION
The "Wait for observed" functions (listed below) now all take in "include_already_visible" (defaulted to true) which includes already visible objects (as these do not create observation events, they would otherwise be ignored), you can obtain the old behavior by passing in include_already_visible=False:
Actions expose more info on success / failure
cube_stack example now more reliable, and includes information on action failure

wait_until_observe_num_objects
wait_for_observed_charger
wait_for_observed_face
wait_for_observed_light_cube