### PR TITLE
Update the use of the observed messages as the syntax is now differen…

### DIFF
--- a/src/cozmo/faces.py
+++ b/src/cozmo/faces.py
@@ -312,7 +312,7 @@ class Face(event.Dispatcher):
         self.last_observed_robot_timestamp = msg.timestamp
         self.last_event_time = time.time()
 
-        image_box = util.ImageBox(msg.img_topLeft_x, msg.img_topLeft_y, msg.img_width, msg.img_height)
+        image_box = util.ImageBox(msg.img_rect.x_topLeft, msg.img_rect.y_topLeft, msg.img_rect.width, msg.img_rect.height)
         self.last_observed_image_box = image_box
 
         self._reset_observed_timeout_handler()

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -279,7 +279,7 @@ class ObservableObject(event.Dispatcher):
         self.last_observed_robot_timestamp = msg.timestamp
         self.last_event_time = time.time()
 
-        image_box = util.ImageBox(msg.img_topLeft_x, msg.img_topLeft_y, msg.img_width, msg.img_height)
+        image_box = util.ImageBox(msg.img_rect.x_topLeft, msg.img_rect.y_topLeft, msg.img_rect.width, msg.img_rect.height)
         self.last_observed_image_box = image_box
 
         self._reset_observed_timeout_handler()


### PR DESCRIPTION
…t (rectangle now inside an img_rect member)