### PR TITLE
COZMO-4894 Expose Robot IMU data

### DIFF
--- a/examples/remote_control_cozmo.py
+++ b/examples/remote_control_cozmo.py
@@ -37,6 +37,11 @@ except ImportError:
     sys.exit("Cannot import from PIL: Do `pip3 install --user Pillow` to install")
 
 
+DEBUG_ANNOTATIONS_DISABLED = 0
+DEBUG_ANNOTATIONS_ENABLED_VISION = 1
+DEBUG_ANNOTATIONS_ENABLED_ALL = 2
+
+
 # Annotator for displaying RobotState (position, etc.) on top of the camera feed
 class RobotStateDisplay(cozmo.annotate.Annotator):
     def apply(self, image, scale):
@@ -45,7 +50,6 @@ class RobotStateDisplay(cozmo.annotate.Annotator):
         bounds = [3, 0, image.width, image.height]
 
         def print_line(text_line):
-            nonlocal bounds
             text = cozmo.annotate.ImageText(text_line, position=cozmo.annotate.TOP_LEFT, color='lightblue')
             text.render(d, bounds)
             TEXT_HEIGHT = 11
@@ -63,7 +67,7 @@ class RobotStateDisplay(cozmo.annotate.Annotator):
 
         # Display the Accelerometer and Gyro data for the robot
 
-        print_line('Acclrm: <%.1f, %.1f, %.1f>' % robot.accelerometer.x_y_z)
+        print_line('Accel: <%.1f, %.1f, %.1f>' % robot.accelerometer.x_y_z)
         print_line('Gyro: <%.1f, %.1f, %.1f>' % robot.gyro.x_y_z)
 
 
@@ -89,9 +93,6 @@ remote_control_cozmo = None
 _default_camera_image = create_default_image(320, 240)
 _is_mouse_look_enabled_by_default = False
 
-DEBUG_ANNOTATIONS_DISABLED = 0
-DEBUG_ANNOTATIONS_ENABLED_VISION = 1
-DEBUG_ANNOTATIONS_ENABLED_ALL = 2
 _display_debug_annotations = DEBUG_ANNOTATIONS_ENABLED_ALL
 
 

--- a/examples/remote_control_cozmo.py
+++ b/examples/remote_control_cozmo.py
@@ -67,7 +67,7 @@ class RobotStateDisplay(cozmo.annotate.Annotator):
 
         # Display the Accelerometer and Gyro data for the robot
 
-        print_line('Accel: <%.1f, %.1f, %.1f>' % robot.accelerometer.x_y_z)
+        print_line('Accelmtr: <%.1f, %.1f, %.1f>' % robot.accelerometer.x_y_z)
         print_line('Gyro: <%.1f, %.1f, %.1f>' % robot.gyro.x_y_z)
 
 

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -638,9 +638,7 @@ class Robot(event.Dispatcher):
 
     @property
     def pose(self):
-        """:class:`cozmo.util.Pose`: The current pose of cozmo relative to where it started
-        (when the engine was initialized, or any delocalizations since - e.g. whenever Cozmo is picked up)
-        Coordinates are in x=forward, y=left, z=up space, following the right hand rule.
+        """:class:`cozmo.util.Pose`: The current pose (position and orientation) of Cozmo
         """
         return self._pose
 
@@ -762,19 +760,19 @@ class Robot(event.Dispatcher):
         self._pose_angle = util.radians(msg.poseAngle_rad) # heading in X-Y plane
         self._pose_pitch = util.radians(msg.posePitch_rad)
         self._head_angle = util.radians(msg.headAngle_rad)
-        self.left_wheel_speed  = util.speed_mmps(msg.leftWheelSpeed_mmps)
+        self.left_wheel_speed = util.speed_mmps(msg.leftWheelSpeed_mmps)
         self.right_wheel_speed = util.speed_mmps(msg.rightWheelSpeed_mmps)
-        self.lift_height       = util.distance_mm(msg.liftHeight_mm)
+        self.lift_height = util.distance_mm(msg.liftHeight_mm)
         self.battery_voltage = msg.batteryVoltage
         self.accelerometer = util.Vector3(msg.accel.x, msg.accel.y, msg.accel.z)
         self.gyro = util.Vector3(msg.gyro.x, msg.gyro.y, msg.gyro.z)
-        self.carrying_object_id        = msg.carryingObjectID      # int_32 will be -1 if not carrying object
-        self.carrying_object_on_top_id = msg.carryingObjectOnTopID # int_32 will be -1 if no object on top of object being carried
-        self.head_tracking_object_id   = msg.headTrackingObjectID  # int_32 will be -1 if head is not tracking to any object
-        self.localized_to_object_id    = msg.localizedToObjectID   # int_32 Will be -1 if not localized to any object
+        self.carrying_object_id = msg.carryingObjectID  # int_32 will be -1 if not carrying object
+        self.carrying_object_on_top_id = msg.carryingObjectOnTopID  # int_32 will be -1 if no object on top of object being carried
+        self.head_tracking_object_id = msg.headTrackingObjectID  # int_32 will be -1 if head is not tracking to any object
+        self.localized_to_object_id = msg.localizedToObjectID  # int_32 Will be -1 if not localized to any object
         self.last_image_robot_timestamp = msg.lastImageTimeStamp
-        self._robot_status_flags       = msg.status     # uint_16 as bitflags - See _clad_to_game_cozmo.RobotStatusFlag
-        self._game_status_flags        = msg.gameStatus # uint_8  as bitflags - See _clad_to_game_cozmo.GameStatusFlag
+        self._robot_status_flags = msg.status  # uint_16 as bitflags - See _clad_to_game_cozmo.RobotStatusFlag
+        self._game_status_flags = msg.gameStatus  # uint_8  as bitflags - See _clad_to_game_cozmo.GameStatusFlag
 
         if msg.robotID != self.robot_id:
             logger.error("robot ID changed mismatch (msg=%s, self=%s)", msg.robotID, self.robot_id )

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -542,6 +542,19 @@ class Robot(event.Dispatcher):
         self.lift_height = None
         #: float: The current battery voltage (not linear, but < 3.5 is low)
         self.battery_voltage = None
+
+        #: :class:`cozmo.util.Vector3`: The current accelerometer reading (x,y,z)
+        #: In mm/s^2, measured in Cozmo's head (e.g. x=0 when Cozmo's head is level
+        #: but x = z = ~7000 mm/s^2 when Cozmo's head is angled 45 degrees up)
+        self.accelerometer = None
+
+        #: :class:`cozmo.util.Vector3`: The current gyro reading (x,y,z)
+        #: In radians/s, measured in Cozmo's head.
+        #: Therefore a large value in a given component would indicate Cozmo is
+        #: being rotated around that axis (where x=forward, y=left, z=up), e.g.
+        #: y = -5 would indicate that Cozmo is being rolled onto his back
+        self.gyro = None
+
         #: int: The ID of the object currently being carried (-1 if none)
         self.carrying_object_id = -1
         #: int: The ID of the object on top of the object currently being carried (-1 if none)
@@ -625,7 +638,9 @@ class Robot(event.Dispatcher):
 
     @property
     def pose(self):
-        """:class:`cozmo.util.Pose`: The current pose of cozmo relative to where he started when the engine was initialized.
+        """:class:`cozmo.util.Pose`: The current pose of cozmo relative to where it started
+        (when the engine was initialized, or any delocalizations since - e.g. whenever Cozmo is picked up)
+        Coordinates are in x=forward, y=left, z=up space, following the right hand rule.
         """
         return self._pose
 
@@ -750,7 +765,9 @@ class Robot(event.Dispatcher):
         self.left_wheel_speed  = util.speed_mmps(msg.leftWheelSpeed_mmps)
         self.right_wheel_speed = util.speed_mmps(msg.rightWheelSpeed_mmps)
         self.lift_height       = util.distance_mm(msg.liftHeight_mm)
-        self.battery_voltage           = msg.batteryVoltage
+        self.battery_voltage = msg.batteryVoltage
+        self.accelerometer = util.Vector3(msg.accel.x, msg.accel.y, msg.accel.z)
+        self.gyro = util.Vector3(msg.gyro.x, msg.gyro.y, msg.gyro.z)
         self.carrying_object_id        = msg.carryingObjectID      # int_32 will be -1 if not carrying object
         self.carrying_object_on_top_id = msg.carryingObjectOnTopID # int_32 will be -1 if no object on top of object being carried
         self.head_tracking_object_id   = msg.headTrackingObjectID  # int_32 will be -1 if head is not tracking to any object

--- a/src/cozmo/util.py
+++ b/src/cozmo/util.py
@@ -487,15 +487,13 @@ def angle_z_to_quaternion(angle_z):
     return q0,q1,q2,q3
 
 
-class Position:
-    '''Represents the position of an object in the world.
-
-    A position consists of its x, y and z values in millimeters.
+class Vector3:
+    '''Represents a 3D Vector (type/units aren't specified)
 
     Args:
-        x (float): X position in millimeters
-        y (float): Y position in millimeters
-        z (float): Z position in millimeters
+        x (float): X component
+        y (float): Y component
+        z (float): Z component
     '''
 
     __slots__ = ('_x', '_y', '_z')
@@ -507,46 +505,58 @@ class Position:
 
     @property
     def x(self):
-        '''float: The x value of this position in millimeters (mm).'''
+        '''float: The x component.'''
         return self._x
 
     @property
     def y(self):
-        '''float: The y value of this position in millimeters (mm).'''
+        '''float: The y component.'''
         return self._y
 
     @property
     def z(self):
-        '''float: The z value of this position in millimeters (mm).'''
+        '''float: The z component.'''
         return self._z
 
     @property
     def x_y_z(self):
-        '''tuple (float, float, float): The X, Y, Z elements of the position (x,y,z)'''
-        return self._x,self._y,self._z
+        '''tuple (float, float, float): The X, Y, Z elements of the Vector3 (x,y,z)'''
+        return self._x, self._y, self._z
 
     def __repr__(self):
         return "<%s x: %.2f y: %.2f z: %.2f>" % (self.__class__.__name__, self.x, self.y, self.z)
 
     def __add__(self, other):
-        if not isinstance(other, Position):
-            raise TypeError("Unsupported operand for + expected Position")
-        return Position(self.x+other.x, self.y+other.y, self.z+other.z)
+        if not isinstance(other, Vector3):
+            raise TypeError("Unsupported operand for + expected Vector3")
+        return Vector3(self.x + other.x, self.y + other.y, self.z + other.z)
 
     def __sub__(self, other):
-        if not isinstance(other, Position):
-            raise TypeError("Unsupported operand for - expected Position")
-        return Position(self.x-other.x, self.y-other.y, self.z-other.z)
+        if not isinstance(other, Vector3):
+            raise TypeError("Unsupported operand for - expected Vector3")
+        return Vector3(self.x - other.x, self.y - other.y, self.z - other.z)
 
     def __mul__(self, other):
         if not isinstance(other, (int, float)):
             raise TypeError("Unsupported operand for * expected number")
-        return Position(self.x*other, self.y*other, self.z*other)
+        return Vector3(self.x * other, self.y * other, self.z * other)
 
     def __truediv__(self, other):
         if not isinstance(other, (int, float)):
             raise TypeError("Unsupported operand for / expected number")
-        return Position(self.x/other, self.y/other, self.z/other)
+        return Vector3(self.x / other, self.y / other, self.z / other)
+
+
+class Position(Vector3):
+    '''Represents the position of an object in the world.
+
+    A position consists of its x, y and z values in millimeters.
+
+    Args:
+        x (float): X position in millimeters
+        y (float): Y position in millimeters
+        z (float): Z position in millimeters
+    '''
 
 
 class Timeout:

--- a/src/cozmo/util.py
+++ b/src/cozmo/util.py
@@ -273,6 +273,23 @@ class Pose:
 
     Use the :func:'pose_z_angle' to return pose in the form of
     position and rotation defined by rotation about the z axis
+
+    When the engine is initialized, and whenever Cozmo is de-localized (i.e.
+    whenever Cozmo no longer knows where he is - e.g. when he's picked up)
+    Cozmo creates a new pose starting at (0,0,0) with no rotation, with
+    origin_id incremented to show that these poses cannot be compared with
+    earlier ones. As Cozmo drives around, his pose (and the pose of other
+    objects he observes - e.g. faces, cubes etc.) is relative to this initial
+    position and orientation.
+
+    The coordinate space is relative to Cozmo, where Cozmo's origin is the
+    point on the ground between Cozmo's two front wheels:
+
+    The X axis is Cozmo's forward direction
+    The Y axis is to Cozmo's left
+    The Z axis is up
+
+    Only poses of the same origin_id can safely be compared or operated on
     '''
 
     __slots__ = ('_position', '_rotation', '_origin_id')


### PR DESCRIPTION
Pull gyro and accelerometer IMU data out of RobotState message and store
Added Vector3 class for storing the above (basically renamed util.Position class, and made Position just a subclass of that)
Slightly more info in robot.pose property docstring
Added (optional) RobotState display annotation to remote_control example for verifying the IMU data
Fixed a couple of small bugs in remote control - updated default animations (2 were removed from 1.1.0), and removed the wait_for_completed on the drive_off_charger_contacts action (it isn't required, and would freeze the camera feed for a second)
Reordered display of remote control key mappings from 0..9 to 1..9,0 to match the layout of the keys on a keyboard.