### PR TITLE
COZMO-7518 Add IR Headlight control

### DIFF
--- a/examples/remote_control_cozmo.py
+++ b/examples/remote_control_cozmo.py
@@ -444,6 +444,7 @@ def handle_index_page():
                         <h3>General:</h3>
                         <b>Shift</b> : Hold to Move Faster (Driving, Head and Lift)<br>
                         <b>Alt</b> : Hold to Move Slower (Driving, Head and Lift)<br>
+                        <b>L</b> : Toggle IR HeadLight: <button id="headLightId" onClick=onHeadLightButtonClicked(this) style="font-size: 14px">Default</button><br>
                         <b>P</b> : Toggle Debug Annotations: <button id="debugAnnotationsId" onClick=onDebugAnnotationsButtonClicked(this) style="font-size: 14px">Default</button><br>
                         <h3>Play Animations</h3>
                         <b>0 .. 9</b> : Play Animation mapped to that key<br>
@@ -463,6 +464,7 @@ def handle_index_page():
                 var gLastClientY = -1
                 var gIsMouseLookEnabled = '''+ to_js_bool_string(_is_mouse_look_enabled_by_default) + '''
                 var gAreDebugAnnotationsEnabled = '''+ str(_display_debug_annotations) + '''
+                var gIsHeadLightEnabled = false
 
                 function postHttpRequest(url, dataSet)
                 {
@@ -544,7 +546,16 @@ def handle_index_page():
                     postHttpRequest("setAreDebugAnnotationsEnabled", {areDebugAnnotationsEnabled})
                 }
 
+                function onHeadLightButtonClicked(button)
+                {
+                    gIsHeadLightEnabled = !gIsHeadLightEnabled;
+                    updateButtonEnabledText(button, gIsHeadLightEnabled);
+                    isHeadLightEnabled = gIsHeadLightEnabled
+                    postHttpRequest("setHeadLightEnabled", {isHeadLightEnabled})
+                }
+
                 updateButtonEnabledText(document.getElementById("mouseLookId"), gIsMouseLookEnabled);
+                updateButtonEnabledText(document.getElementById("headLightId"), gIsHeadLightEnabled);
                 updateDebugAnnotationButtonEnabledText(document.getElementById("debugAnnotationsId"), gAreDebugAnnotationsEnabled);
 
                 function handleDropDownSelect(selectObject)
@@ -563,7 +574,12 @@ def handle_index_page():
 
                     if (actionType=="keyup")
                     {
-                        if (keyCode == 80) // 'P'
+                        if (keyCode == 76) // 'L'
+                        {
+                            // Simulate a click of the headlight button
+                            onHeadLightButtonClicked(document.getElementById("headLightId"))
+                        }
+                        else if (keyCode == 80) // 'P'
                         {
                             // Simulate a click of the debug annotations button
                             onDebugAnnotationsButtonClicked(document.getElementById("debugAnnotationsId"))
@@ -676,6 +692,15 @@ def handle_setMouseLookEnabled():
     message = json.loads(request.data.decode("utf-8"))
     if remote_control_cozmo:
         remote_control_cozmo.set_mouse_look_enabled(is_mouse_look_enabled=message['isMouseLookEnabled'])
+    return ""
+
+
+@flask_app.route('/setHeadLightEnabled', methods=['POST'])
+def handle_setHeadLightEnabled():
+    '''Called from Javascript whenever head-light enabled is toggled'''
+    message = json.loads(request.data.decode("utf-8"))
+    if remote_control_cozmo:
+        remote_control_cozmo.cozmo.set_head_light(enable=message['isHeadLightEnabled'])
     return ""
 
 

--- a/examples/remote_control_cozmo.py
+++ b/examples/remote_control_cozmo.py
@@ -444,7 +444,7 @@ def handle_index_page():
                         <h3>General:</h3>
                         <b>Shift</b> : Hold to Move Faster (Driving, Head and Lift)<br>
                         <b>Alt</b> : Hold to Move Slower (Driving, Head and Lift)<br>
-                        <b>L</b> : Toggle IR HeadLight: <button id="headLightId" onClick=onHeadLightButtonClicked(this) style="font-size: 14px">Default</button><br>
+                        <b>L</b> : Toggle IR Headlight: <button id="headlightId" onClick=onHeadlightButtonClicked(this) style="font-size: 14px">Default</button><br>
                         <b>P</b> : Toggle Debug Annotations: <button id="debugAnnotationsId" onClick=onDebugAnnotationsButtonClicked(this) style="font-size: 14px">Default</button><br>
                         <h3>Play Animations</h3>
                         <b>0 .. 9</b> : Play Animation mapped to that key<br>
@@ -464,7 +464,7 @@ def handle_index_page():
                 var gLastClientY = -1
                 var gIsMouseLookEnabled = '''+ to_js_bool_string(_is_mouse_look_enabled_by_default) + '''
                 var gAreDebugAnnotationsEnabled = '''+ str(_display_debug_annotations) + '''
-                var gIsHeadLightEnabled = false
+                var gIsHeadlightEnabled = false
 
                 function postHttpRequest(url, dataSet)
                 {
@@ -546,16 +546,16 @@ def handle_index_page():
                     postHttpRequest("setAreDebugAnnotationsEnabled", {areDebugAnnotationsEnabled})
                 }
 
-                function onHeadLightButtonClicked(button)
+                function onHeadlightButtonClicked(button)
                 {
-                    gIsHeadLightEnabled = !gIsHeadLightEnabled;
-                    updateButtonEnabledText(button, gIsHeadLightEnabled);
-                    isHeadLightEnabled = gIsHeadLightEnabled
-                    postHttpRequest("setHeadLightEnabled", {isHeadLightEnabled})
+                    gIsHeadlightEnabled = !gIsHeadlightEnabled;
+                    updateButtonEnabledText(button, gIsHeadlightEnabled);
+                    isHeadlightEnabled = gIsHeadlightEnabled
+                    postHttpRequest("setHeadlightEnabled", {isHeadlightEnabled})
                 }
 
                 updateButtonEnabledText(document.getElementById("mouseLookId"), gIsMouseLookEnabled);
-                updateButtonEnabledText(document.getElementById("headLightId"), gIsHeadLightEnabled);
+                updateButtonEnabledText(document.getElementById("headlightId"), gIsHeadlightEnabled);
                 updateDebugAnnotationButtonEnabledText(document.getElementById("debugAnnotationsId"), gAreDebugAnnotationsEnabled);
 
                 function handleDropDownSelect(selectObject)
@@ -577,7 +577,7 @@ def handle_index_page():
                         if (keyCode == 76) // 'L'
                         {
                             // Simulate a click of the headlight button
-                            onHeadLightButtonClicked(document.getElementById("headLightId"))
+                            onHeadlightButtonClicked(document.getElementById("headlightId"))
                         }
                         else if (keyCode == 80) // 'P'
                         {
@@ -695,12 +695,12 @@ def handle_setMouseLookEnabled():
     return ""
 
 
-@flask_app.route('/setHeadLightEnabled', methods=['POST'])
-def handle_setHeadLightEnabled():
-    '''Called from Javascript whenever head-light enabled is toggled'''
+@flask_app.route('/setHeadlightEnabled', methods=['POST'])
+def handle_setHeadlightEnabled():
+    '''Called from Javascript whenever headlight is toggled on/off'''
     message = json.loads(request.data.decode("utf-8"))
     if remote_control_cozmo:
-        remote_control_cozmo.cozmo.set_head_light(enable=message['isHeadLightEnabled'])
+        remote_control_cozmo.cozmo.set_head_light(enable=message['isHeadlightEnabled'])
     return ""
 
 

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -920,6 +920,20 @@ class Robot(event.Dispatcher):
         light_arr = [ lights.off_light ] * 5
         self.set_backpack_lights(*light_arr)
 
+    def set_head_light(self, enable):
+        '''Turn Cozmo's IR headlight on or off.
+
+        The headlight is on the front of Cozmo's chassis, between his two
+        front wheels, underneath his head. Cozmo's camera is IR sensitive
+        so although you cannot see the IR light with the naked eye you will
+        see it in Cozmo's camera feed.
+
+        Args:
+            enable (bool): True turns the light on, False turns it off.
+        '''
+        msg = _clad_to_engine_iface.SetHeadlight(enable=enable)
+        self.conn.send_msg(msg)
+
     def set_head_angle(self, angle, accel=10.0, max_speed=10.0, duration=0.0):
         '''Tell Cozmo's head to turn to a given angle.
 


### PR DESCRIPTION
Add robot.set_head_light method to turn IR headlight on and off
Added keyboard and button mappings to turn IR light on and off in the remote_control_cozmo example program