### PR TITLE
COZMO-7567 Get Available Objects before Robot Ready

### DIFF
--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -376,10 +376,18 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
 
         self._is_ui_connected = True
         self.dispatch_event(EvtConnected, conn=self)
-        self.anim_names.refresh()
+
         logger.info('App connection established. sdk_version=%s '
                 'cozmoclad_version=%s app_build_version=%s',
                 version.__version__, cozmoclad.__version__, msg.buildVersion)
+
+        # We RequestAvailableObjects before the animation names as this ensures
+        # that we will receive the responses before we mark the robot as ready
+        msg = _clad_to_engine_iface.RequestAvailableObjects()
+        self.send_msg(msg)
+
+        self.anim_names.refresh()
+
 
     def _recv_msg_image_chunk(self, evt, *, msg):
         if self._primary_robot:

--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -381,13 +381,13 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
                 'cozmoclad_version=%s app_build_version=%s',
                 version.__version__, cozmoclad.__version__, msg.buildVersion)
 
-        # We RequestAvailableObjects before the animation names as this ensures
-        # that we will receive the responses before we mark the robot as ready
+        # We send RequestAvailableObjects before refreshing the animation names
+        # as this ensures that we will receive the responses before we mark the
+        # robot as ready
         msg = _clad_to_engine_iface.RequestAvailableObjects()
         self.send_msg(msg)
 
         self.anim_names.refresh()
-
 
     def _recv_msg_image_chunk(self, evt, *, msg):
         if self._primary_robot:

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -352,7 +352,7 @@ class ObservableObject(ObservableElement):
 LightCube1Id = _clad_to_game_cozmo.ObjectType.Block_LIGHTCUBE1
 #: LightCube2Id's markers look a bit like a lamp
 LightCube2Id = _clad_to_game_cozmo.ObjectType.Block_LIGHTCUBE2
-#: LightCube3Id's markers look a bit like the letters ab over T
+#: LightCube3Id's markers look a bit like the letters 'ab' over 'T'
 LightCube3Id = _clad_to_game_cozmo.ObjectType.Block_LIGHTCUBE3
 
 

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -37,7 +37,7 @@ online documentation.  They will be detected as :class:`CustomObject` instances.
 
 
 # __all__ should order by constants, event classes, other classes, functions.
-__all__ = ['OBJECT_VISIBILITY_TIMEOUT',
+__all__ = ['LightCube1Id', 'LightCube2Id', 'LightCube3Id', 'OBJECT_VISIBILITY_TIMEOUT',
            'EvtObjectAppeared', 'EvtObjectAvailable', 'EvtObjectTapped',
            'EvtObjectConnectChanged', 'EvtObjectDisappeared', 'EvtObjectObserved',
            'ObservableElement', 'ObservableObject', 'LightCube', 'Charger',
@@ -348,8 +348,11 @@ class ObservableObject(ObservableElement):
     #### Commands ####
 
 
+#: LightCube1Id's markers look a bit like a paperclip
 LightCube1Id = _clad_to_game_cozmo.ObjectType.Block_LIGHTCUBE1
+#: LightCube2Id's markers look a bit like a lamp
 LightCube2Id = _clad_to_game_cozmo.ObjectType.Block_LIGHTCUBE2
+#: LightCube3Id's markers look a bit like the letters ab over T
 LightCube3Id = _clad_to_game_cozmo.ObjectType.Block_LIGHTCUBE3
 
 

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -598,9 +598,6 @@ class Robot(event.Dispatcher):
             await self.world.delete_all_custom_objects()
             self._reset_behavior_state()
 
-            msg = _clad_to_engine_iface.RequestAvailableObjects()
-            self.conn.send_msg(msg)
-
             # wait for animations to load
             await self.conn.anim_names.wait_for_loaded()
 


### PR DESCRIPTION
Request the available objects earlier, before requesting the available animations - this ensures we have received the available objects before we mark the robot as ready, because we already wait on the animation list to arrive. (Note: adding an additional check to wait for available objects wouldn't be possible without an app change, because there's no guarantee of any message in the case that all cubes and charger are disconnected).