### PR TITLE
COZMO-7703 Fix TurnTowardsFace turning angle

### DIFF
--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -390,7 +390,8 @@ class TurnTowardsFace(action.Action):
 
     def _encode(self):
         return _clad_to_engine_iface.TurnTowardsFace(
-            faceID=self.face.face_id)
+            faceID=self.face.face_id,
+            maxTurnAngle_rad=util.degrees(180).radians)
 
 
 


### PR DESCRIPTION
Since the 1.1.0 version of the app the maxTurnAngle_rad value must be > 0 to allow Cozmo to turn whilst performing TurnTowardsFace, without this Cozmo will only look up and down.