### PR TITLE
COZMO-6362 Parallel Action Support

### DIFF
--- a/examples/tutorials/06_actions/01_parallel_actions.py
+++ b/examples/tutorials/06_actions/01_parallel_actions.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2016 Anki, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the file LICENSE.txt or at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''Parallel Action Examples.
+
+This script shows how to run actions in parallel instead of in sequence,
+how some actions will fail to run if another action is already using that
+animation track, and how you can abort individual, or all, actions.
+'''
+
+import sys
+import time
+
+try:
+    from PIL import Image
+except ImportError:
+    sys.exit("Cannot import from PIL: Do `pip3 install --user Pillow` to install")
+
+import cozmo
+from cozmo.util import degrees, distance_mm, speed_mmps
+
+
+# load an image to display on Cozmo's face
+face_image = Image.open("../../face_images/cozmosdk.png")
+# resize to fit on Cozmo's face screen
+face_image = face_image.resize(cozmo.oled_face.dimensions(), Image.BICUBIC)
+# convert the image to the format used by the oled screen
+face_image = cozmo.oled_face.convert_image_to_screen_data(face_image,
+                                                          invert_image=True)
+
+
+def example1_lift_head(robot: cozmo.robot.Robot):
+    cozmo.logger.info("----------------------------------------")
+    cozmo.logger.info("Example 1: Move Lift and Head in Parallel")
+    cozmo.logger.info("First, move the lift and head down, in sequence.")
+    robot.set_head_angle(cozmo.robot.MIN_HEAD_ANGLE).wait_for_completed()
+    robot.set_lift_height(0.0).wait_for_completed()
+
+    cozmo.logger.info("Now, move the lift and head back up, in parallel "
+                      "- we no longer have to wait for the 1st action to complete "
+                      "before starting the 2nd one because the 2nd action is in_parallel")
+    action1 = robot.set_head_angle(cozmo.robot.MAX_HEAD_ANGLE)
+    action2 = robot.set_lift_height(1.0, in_parallel=True)
+    action1.wait_for_completed()
+    action2.wait_for_completed()
+    cozmo.logger.info("action1 = %s", action1)
+    cozmo.logger.info("action2 = %s", action2)
+
+
+def example2_conflicting_actions(robot: cozmo.robot.Robot):
+    cozmo.logger.info("----------------------------------------")
+    cozmo.logger.info("Example 2: Conflicting actions.")
+    cozmo.logger.info("Try to drive straight and turn in parallel. This is not "
+          "allowed, as both actions require use of the wheels, so the 2nd action "
+          "will report failure due to tracks_locked.")
+    action1 = robot.drive_straight(distance_mm(50), speed_mmps(25), should_play_anim=False, in_parallel=True)
+    action2 = robot.turn_in_place(degrees(90), in_parallel=True)
+    action2.wait_for_completed()
+    cozmo.logger.info("action2 = %s", action2)
+    action1.wait_for_completed()
+    cozmo.logger.info("action1 = %s", action1)
+
+
+def example3_abort_one_action(robot: cozmo.robot.Robot):
+    cozmo.logger.info("----------------------------------------")
+    cozmo.logger.info("Example 3: Abort some parallel actions.")
+    cozmo.logger.info("Start multiple parallel actions:")
+    action1 = robot.set_lift_height(0.0, in_parallel=True)
+    action2 = robot.set_head_angle(cozmo.robot.MIN_HEAD_ANGLE, duration=6.0, in_parallel=True)
+    action3 = robot.drive_straight(distance_mm(75), speed_mmps(25), should_play_anim=False, in_parallel=True)
+    action4 = robot.display_oled_face_image(face_image, 30000.0)  # Note: face image is in_parallel by default
+    # Lift-lowering is aborted immediately
+    action1.abort()
+    # Head-lowering is aborted shortly afterwards
+    time.sleep(0.1)
+    action2.abort()
+    # Image on Cozmo's face is aborted another 2 seconds later
+    time.sleep(2)
+    action4.abort()
+    # We wait for the one remaining action to complete
+    action3.wait_for_completed()
+    # Only action3 should succeed (as long as Cozmo had enough space to drive)
+    cozmo.logger.info("action1 = %s", action1)
+    cozmo.logger.info("action2 = %s", action2)
+    cozmo.logger.info("action3 = %s", action3)
+    cozmo.logger.info("action4 = %s", action4)
+
+
+def example4_abort_all_actions(robot: cozmo.robot.Robot):
+    cozmo.logger.info("----------------------------------------")
+    cozmo.logger.info("Example 4: Abort all parallel actions.")
+    cozmo.logger.info("Start multiple parallel actions:")
+    action1 = robot.set_lift_height(0.0, in_parallel=True, duration=6.0)
+    action2 = robot.set_head_angle(cozmo.robot.MAX_HEAD_ANGLE, duration=6.0, in_parallel=True)
+    action3 = robot.drive_straight(distance_mm(75), speed_mmps(25), should_play_anim=False, in_parallel=True)
+    action4 = robot.display_oled_face_image(face_image, 30000.0)  # Note: face image is in_parallel by default
+    # wait two seconds and abort everything
+    time.sleep(2)
+    robot.abort_all_actions()
+    # wait for results to come back for all actions
+    robot.wait_for_all_actions_completed()
+    # All actions should have aborted
+    cozmo.logger.info("action1 res = %s", action1)
+    cozmo.logger.info("action2 res = %s", action2)
+    cozmo.logger.info("action3 res = %s", action3)
+    cozmo.logger.info("action4 res = %s", action4)
+
+
+def cozmo_program(robot: cozmo.robot.Robot):
+    example1_lift_head(robot)
+    example2_conflicting_actions(robot)
+    example3_abort_one_action(robot)
+    example4_abort_all_actions(robot)
+    cozmo.logger.info("----------------------------------------")
+
+
+cozmo.run_program(cozmo_program)

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -36,8 +36,9 @@ methods such as :meth:`~cozmo.event.Dispatcher.wait_for` and
 # __all__ should order by constants, event classes, other classes, functions.
 __all__ = ['MAX_HEAD_ANGLE', 'MIN_HEAD_ANGLE', 'MIN_LIFT_HEIGHT_MM', 'MAX_LIFT_HEIGHT_MM',
            'EvtRobotReady',
-           'GoToPose', 'DriveOffChargerContacts', 'DriveStraight', 'PickupObject',
-           'PlaceOnObject', 'PlaceObjectOnGroundHere', 'SayText', 'SetHeadAngle',
+           'GoToPose', 'DisplayOledFaceImage', 'DriveOffChargerContacts',
+           'DriveStraight', 'PickupObject', 'PlaceOnObject',
+           'PlaceObjectOnGroundHere', 'SayText', 'SetHeadAngle',
            'SetLiftHeight', 'TurnInPlace', 'TurnTowardsFace',
            'Robot']
 
@@ -171,6 +172,34 @@ class DriveStraight(action.Action):
         return _clad_to_engine_iface.DriveStraight(speed_mmps=self.speed.speed_mmps,
                                                    dist_mm=self.distance.distance_mm,
                                                    shouldPlayAnimation=self.should_play_anim)
+
+
+class DisplayOledFaceImage(action.Action):
+    '''Represents the "display oled face image" action in progress.
+
+    Returned by :meth:`~cozmo.robot.Robot.display_oled_face_image`
+    '''
+
+    _action_type = _clad_to_engine_cozmo.RobotActionType.DISPLAY_FACE_IMAGE
+
+    # Face images are sent so frequently, with the previous face image always
+    # aborted, that logging each event would spam the log.
+    _enable_abort_logging = False
+
+    def __init__(self, screen_data, duration_ms, **kw):
+        super().__init__(**kw)
+        #: :class:`bytes`: a sequence of pixels (8 pixels per byte)
+        self.screen_data = screen_data
+        #: float: time to keep displaying this image on Cozmo's face
+        self.duration_ms = duration_ms
+
+    def _repr_values(self):
+        return "screen_data=%s Bytes duration_ms=%s" %\
+               (len(self.screen_data), self.duration_ms)
+
+    def _encode(self):
+        return _clad_to_engine_iface.DisplayFaceImage(faceData=self.screen_data,
+                                                      duration_ms=self.duration_ms)
 
 
 class PickupObject(action.Action):
@@ -485,6 +514,10 @@ class Robot(event.Dispatcher):
     #: :class:`DriveStraight` class or subclass instance.
     drive_straight_factory = DriveStraight
 
+    #: callable: The factory function that returns a
+    #: :class:`DisplayOledFaceImage` class or subclass instance.
+    display_oled_face_image_factory = DisplayOledFaceImage
+
     # other factories
 
     #: callable: The factory function that returns a
@@ -537,6 +570,8 @@ class Robot(event.Dispatcher):
         self.world = self.world_factory(self.conn, self, dispatch_parent=self)
 
         self._action_dispatcher = self._action_dispatcher_factory(self)
+
+        self._current_face_image_action = None
 
         #: :class:`cozmo.util.Speed`: Speed of the left wheel
         self.left_wheel_speed = None
@@ -763,6 +798,11 @@ class Robot(event.Dispatcher):
         '''
         return self._is_freeplay_mode_active
 
+    @property
+    def has_in_progress_actions(self):
+        '''bool: True if Cozmo has any SDK-triggered actions still in progress.'''
+        return self._action_dispatcher.has_in_progress_actions
+
     #### Private Event Handlers ####
 
     #def _recv_default_handler(self, event, **kw):
@@ -831,10 +871,7 @@ class Robot(event.Dispatcher):
 
         Abort / Cancel any action that is currently either running or queued within the engine
         '''
-        # RobotActionType.UNKNOWN is a wildcard that matches all actions when cancelling.
-        msg = _clad_to_engine_iface.CancelAction(robotID=self.robot_id,
-                                                 actionType=_clad_to_engine_cozmo.RobotActionType.UNKNOWN)
-        self.conn.send_msg(msg)
+        self._action_dispatcher._abort_all_actions()
 
     def enable_facial_expression_estimation(self, enable=True):
         '''Enable or Disable facial expression estimation
@@ -912,7 +949,8 @@ class Robot(event.Dispatcher):
         msg = _clad_to_engine_iface.MoveLift(speed_rad_per_sec=speed)
         self.conn.send_msg(msg)
 
-    def say_text(self, text, play_excited_animation=False, use_cozmo_voice=True, duration_scalar=1.8, voice_pitch=0.0):
+    def say_text(self, text, play_excited_animation=False, use_cozmo_voice=True,
+                 duration_scalar=1.8, voice_pitch=0.0, in_parallel=False, num_retries=0):
         '''Have Cozmo say text!
 
         Args:
@@ -924,6 +962,11 @@ class Robot(event.Dispatcher):
             duration_scalar (float): Adjust the relative duration of the
                 generated text to speech audio.
             voice_pitch (float): Adjust the pitch of Cozmo's robot voice [-1.0, 1.0]
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
             A :class:`cozmo.robot.SayText` action object which can be
                 queried to see when it is complete
@@ -933,7 +976,9 @@ class Robot(event.Dispatcher):
                                        use_cozmo_voice=use_cozmo_voice, duration_scalar=duration_scalar,
                                        voice_pitch=voice_pitch, conn=self.conn,
                                        robot=self, dispatch_parent=self)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
     def set_backpack_lights(self, light1, light2, light3, light4, light5):
@@ -1001,7 +1046,8 @@ class Robot(event.Dispatcher):
         msg = _clad_to_engine_iface.SetHeadlight(enable=enable)
         self.conn.send_msg(msg)
 
-    def set_head_angle(self, angle, accel=10.0, max_speed=10.0, duration=0.0):
+    def set_head_angle(self, angle, accel=10.0, max_speed=10.0, duration=0.0,
+                       in_parallel=False, num_retries=0):
         '''Tell Cozmo's head to turn to a given angle.
 
         Args:
@@ -1010,7 +1056,13 @@ class Robot(event.Dispatcher):
                 :const:`MAX_HEAD_ANGLE`).
             accel (float): Acceleration of Cozmo's head in radians per second squared.
             max_speed (float): Maximum speed of Cozmo's head in radians per second.
-            duration (float): Time for Cozmo's head to turn in seconds.
+            duration (float): Time for Cozmo's head to turn in seconds. A value
+                of zero will make Cozmo try to do it as quickly as possible.
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
             A :class:`cozmo.robot.SetHeadAngle` action object which can be
                 queried to see when it is complete
@@ -1019,10 +1071,13 @@ class Robot(event.Dispatcher):
                 accel=accel, duration=duration, conn=self.conn,
                 robot=self, dispatch_parent=self)
 
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
-    def set_lift_height(self, height, accel=1.0, max_speed=1.0, duration=2.0):
+    def set_lift_height(self, height, accel=10.0, max_speed=10.0, duration=0.0,
+                        in_parallel=False, num_retries=0):
         '''Tell Cozmo's lift to move to a given height
 
         Args:
@@ -1031,7 +1086,13 @@ class Robot(event.Dispatcher):
             accel (float): Acceleration of Cozmo's lift in radians per
                 second squared.
             max_speed (float): Maximum speed of Cozmo's lift in radians per second.
-            duration (float): Time for Cozmo's lift to move in seconds.
+            duration (float): Time for Cozmo's lift to move in seconds. A value
+                of zero will make Cozmo try to do it as quickly as possible.
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
             A :class:`cozmo.robot.SetLiftHeight` action object which can be
                 queried to see when it is complete.
@@ -1039,13 +1100,15 @@ class Robot(event.Dispatcher):
         action = self.set_lift_height_factory(height=height, max_speed=max_speed,
                 accel=accel, duration=duration, conn=self.conn,
                 robot=self, dispatch_parent=self)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
 
     ## Animation Commands ##
 
-    def play_anim(self, name, loop_count=1):
+    def play_anim(self, name, loop_count=1, in_parallel=False, num_retries=0):
         '''Starts an animation playing on a robot.
 
         Returns an Animation object as soon as the request to play the animation
@@ -1060,6 +1123,11 @@ class Robot(event.Dispatcher):
         Args:
             name (str): The name of the animation to play.
             loop_count (int): Number of times to play the animation.
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
             A :class:`cozmo.anim.Animation` action object which can be queried
                 to see when it is complete.
@@ -1070,10 +1138,13 @@ class Robot(event.Dispatcher):
             raise ValueError('Unknown animation name "%s"' % name)
         action = self.animation_factory(name, loop_count,
                 conn=self.conn, robot=self, dispatch_parent=self)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
-    def play_anim_trigger(self, trigger, loop_count=1):
+    def play_anim_trigger(self, trigger, loop_count=1, in_parallel=False,
+                          num_retries=0):
         """Starts an animation trigger playing on a robot.
 
         As noted in the Triggers class, playing a trigger requests that an
@@ -1083,6 +1154,11 @@ class Robot(event.Dispatcher):
         Args:
             trigger (object): An attribute of the :class:`cozmo.anim.Triggers` class
             loop_count (int): Number of times to play the animation
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
             A :class:`cozmo.anim.AnimationTrigger` action object which can be
                 queried to see when it is complete
@@ -1094,7 +1170,9 @@ class Robot(event.Dispatcher):
 
         action = self.animation_trigger_factory(trigger, loop_count,
             conn=self.conn, robot=self, dispatch_parent=self)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
     def set_idle_animation(self, anim_trigger):
@@ -1123,7 +1201,8 @@ class Robot(event.Dispatcher):
 
     # Cozmo's Face animation commands
 
-    def display_oled_face_image(self, screen_data, duration_ms):
+    def display_oled_face_image(self, screen_data, duration_ms,
+                                in_parallel=True):
         ''' Display a bitmap image on Cozmo's OLED face screen.
 
         Args:
@@ -1132,9 +1211,32 @@ class Robot(event.Dispatcher):
                 :func:`cozmo.oled_face.convert_pixels_to_screen_data`).
             duration_ms (float): time to keep displaying this image on Cozmo's
                 face (clamped to 30 seconds in engine).
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+        Returns:
+            A :class:`cozmo.robot.DisplayOledFaceImage` action object which
+                can be queried to see when it is complete.
+        Raises:
+            :class:`cozmo.exceptions.RobotBusy` if another action is already
+                running and in_parallel==False
         '''
-        msg = _clad_to_engine_iface.DisplayFaceImage(faceData=screen_data, duration_ms=duration_ms)
-        self.conn.send_msg(msg)
+
+        # We never want 2 face image actions active at once, so clear current
+        # face image action (if one is running)
+        if ((self._current_face_image_action is not None) and
+                self._current_face_image_action.is_running):
+            self._current_face_image_action.abort()
+
+        action = self.display_oled_face_image_factory(screen_data=screen_data,
+                                                      duration_ms=duration_ms,
+                                                      conn=self.conn, robot=self,
+                                                      dispatch_parent=self)
+        self._current_face_image_action = action
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=0)
+        return action
 
 
     ## Behavior Commands ##
@@ -1211,7 +1313,8 @@ class Robot(event.Dispatcher):
 
     ## Object Commands ##
 
-    def pickup_object(self, obj, use_pre_dock_pose=True):
+    def pickup_object(self, obj, use_pre_dock_pose=True, in_parallel=False,
+                      num_retries=0):
         '''Instruct the robot to pick-up the supplied object.
 
         Args:
@@ -1219,11 +1322,17 @@ class Robot(event.Dispatcher):
                 pick up where ``obj.pickupable`` is True.
             use_pre_dock_pose (bool): whether or not to try to immediately pick
                 up an object or first position the robot next to the object.
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
             A :class:`cozmo.robot.PickupObject` action object which can be
                 queried to see when it is complete.
         Raises:
-            :class:`cozmo.exceptions.RobotBusy` if another action is already running.
+            :class:`cozmo.exceptions.RobotBusy` if another action is already
+                running and in_parallel==False
             :class:`cozmo.exceptions.NotPickupable` if object type can't be picked up.
         '''
         if not obj.pickupable:
@@ -1233,10 +1342,13 @@ class Robot(event.Dispatcher):
         logger.info("Sending pickup object request for object=%s", obj)
         action = self.pickup_object_factory(obj=obj, use_pre_dock_pose=use_pre_dock_pose,
                 conn=self.conn, robot=self, dispatch_parent=self)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
-    def place_on_object(self, obj, use_pre_dock_pose=True):
+    def place_on_object(self, obj, use_pre_dock_pose=True, in_parallel=False,
+                        num_retries=0):
         '''Asks Cozmo to place the currently held object onto a target object.
 
         Args:
@@ -1245,11 +1357,17 @@ class Robot(event.Dispatcher):
                 is True.
             use_pre_dock_pose (bool): Whether or not to try to immediately pick
                 up an object or first position the robot next to the object.
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
             A :class:`cozmo.robot.PlaceOnObject` action object which can be
                 queried to see when it is complete.
         Raises:
-            :class:`cozmo.exceptions.RobotBusy` if another action is already running
+            :class:`cozmo.exceptions.RobotBusy` if another action is already
+                running and in_parallel==False
             :class:`cozmo.exceptions.CannotPlaceObjectsOnThis` if the object cannot have objects
             placed on it.
         '''
@@ -1260,46 +1378,65 @@ class Robot(event.Dispatcher):
         logger.info("Sending place on object request for target object=%s", obj)
         action = self.place_on_object_factory(obj=obj, use_pre_dock_pose=use_pre_dock_pose,
                 conn=self.conn, robot=self, dispatch_parent=self)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
-    def place_object_on_ground_here(self, obj):
+    def place_object_on_ground_here(self, obj, in_parallel=False, num_retries=0):
         '''Ask Cozmo to place the object he is carrying on the ground at the current location.
 
+        Args:
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
             A :class:`cozmo.robot.PlaceObjectOnGroundHere` action object which
                 can be queried to see when it is complete.
         Raises:
-            :class:`cozmo.exceptions.RobotBusy` if another action is already running
+            :class:`cozmo.exceptions.RobotBusy` if another action is already
+                running and in_parallel==False
         '''
         # TODO: Check whether Cozmo is known to be holding the object in question
         logger.info("Sending place down here request for object=%s", obj)
         action = self.place_object_on_ground_here_factory(obj=obj,
                 conn=self.conn, robot=self, dispatch_parent=self)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
 
     ## Interact with seen Face Commands ##
 
-    def turn_towards_face(self, face):
+    def turn_towards_face(self, face, in_parallel=False, num_retries=0):
         '''Tells Cozmo to turn towards this face.
 
         Args:
             face: (:class:`cozmo.faces.Face`): The face Cozmo will turn towards.
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
             A :class:`cozmo.robot.TurnTowardsFace` action object which can be
                 queried to see when it is complete
         '''
         action = self.turn_towards_face_factory(face=face,
                 conn=self.conn, robot=self, dispatch_parent=self)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
 
     ## Robot Driving Commands ##
 
-    def go_to_pose(self, pose, relative_to_robot=False):
+    def go_to_pose(self, pose, relative_to_robot=False, in_parallel=False,
+                   num_retries=0):
         '''Tells Cozmo to drive to the specified pose and orientation.
 
         If relative_to_robot is set to True, the given pose will assume the
@@ -1314,6 +1451,11 @@ class Robot(event.Dispatcher):
             pose: (:class:`cozmo.util.Pose`): The destination pose.
             relative_to_robot (bool): Whether the given pose is relative to
                 the robot's pose.
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
             A :class:`cozmo.robot.GoToPose` action object which can be queried
                 to see when it is complete.
@@ -1322,10 +1464,13 @@ class Robot(event.Dispatcher):
             pose = self.pose.define_pose_relative_this(pose)
         action = self.go_to_pose_factory(pose=pose,
                 conn=self.conn, robot=self, dispatch_parent=self)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
-    def go_to_object(self, target_object, distance_from_object):
+    def go_to_object(self, target_object, distance_from_object,
+                     in_parallel=False, num_retries=0):
         '''Tells Cozmo to drive to the specified object.
 
         Args:
@@ -1334,6 +1479,11 @@ class Robot(event.Dispatcher):
                 object to stop. This is the distance between the origins. For instance,
                 the distance from the robot's origin (between Cozmo's two front wheels)
                 to the cube's origin (at the center of the cube) is ~40mm.
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
             A :class:`cozmo.robot.GoToObject` action object which can be queried
                 to see when it is complete.
@@ -1344,15 +1494,22 @@ class Robot(event.Dispatcher):
         action = self.go_to_object_factory(object_id=target_object.object_id,
                                            distance_from_object=distance_from_object,
                                            conn=self.conn, robot=self, dispatch_parent=self)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
-    def turn_in_place(self, angle):
+    def turn_in_place(self, angle, in_parallel=False, num_retries=0):
         '''Turn the robot around its current position.
 
         Args:
             angle: (:class:`cozmo.util.Angle`): The angle to turn. Positive
                 values turn to the left, negative values to the right.
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
             A :class:`cozmo.robot.TurnInPlace` action object which can be
                 queried to see when it is complete.
@@ -1360,10 +1517,12 @@ class Robot(event.Dispatcher):
         # TODO: add support for absolute vs relative positioning, speed & accel options
         action = self.turn_in_place_factory(angle=angle,
                 conn=self.conn, robot=self, dispatch_parent=self)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
-    def drive_off_charger_contacts(self):
+    def drive_off_charger_contacts(self, in_parallel=False, num_retries=0):
         '''Tells Cozmo to drive forward slightly to get off the charger contacts.
 
         All motor movement is disabled while Cozmo is on the charger to
@@ -1371,13 +1530,21 @@ class Robot(event.Dispatcher):
         a way to drive forward a little to disconnect from the charger contacts
         and thereby re-enable all other commands.
 
+        Args:
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
            A :class:`cozmo.robot.DriveOffChargerContacts` action object which
             can be queried to see when it is complete.
         '''
         action = self.drive_off_charger_contacts_factory(conn=self.conn,
                 robot=self, dispatch_parent=self)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
 
     async def backup_onto_charger(self, max_drive_time=3):
@@ -1420,7 +1587,8 @@ class Robot(event.Dispatcher):
         '''
         return self.perform_off_charger_factory(self)
 
-    def drive_straight(self, distance, speed, should_play_anim=True):
+    def drive_straight(self, distance, speed, should_play_anim=True,
+                       in_parallel=False, num_retries=0):
         '''Tells Cozmo to drive in a straight line
 
         Cozmo will drive for the specified distance (forwards or backwards)
@@ -1432,7 +1600,11 @@ class Robot(event.Dispatcher):
                 (should always be >0, the abs(speed) is used internally)
             should_play_anim (bool): Whether to play idle animations
                 whilst driving (tilt head, hum, animated eyes, etc.)
-
+            in_parallel (bool): True to run this action in parallel with
+                previous actions, False to require that all previous actions
+                be already complete.
+            num_retries (int): Number of times to retry the action if the
+                previous attempt(s) failed.
         Returns:
            A :class:`cozmo.robot.DriveStraight` action object which
             can be queried to see when it is complete.
@@ -1443,5 +1615,11 @@ class Robot(event.Dispatcher):
                                              distance=distance,
                                              speed=speed,
                                              should_play_anim=should_play_anim)
-        self._action_dispatcher._send_single_action(action)
+        self._action_dispatcher._send_single_action(action,
+                                                    in_parallel=in_parallel,
+                                                    num_retries=num_retries)
         return action
+
+    async def wait_for_all_actions_completed(self):
+        '''Waits until all SDK-initiated actions are complete.'''
+        await self._action_dispatcher.wait_for_all_actions_completed()


### PR DESCRIPTION
Adding in_parallel parameter for all actions, this tells engine to run in parallel (and not clear current actions), and also prevents the SDK from raising an exception if there were pending actions in that case.
OLED face image is now an sent as a parallel action, with previous face actions automatically aborted each time
Aborted actions are immediately not considered in-progress (no longer have to wait a frame for engine to return the cancelled message before starting another action)
Added 06_actions/01_parallel_actions.py example to demonstrate the above.