### PR TITLE
COZMO-7694 Check validity of poses

### DIFF
--- a/examples/tutorials/04_cubes_and_objects/08_drive_to_charger_test.py
+++ b/examples/tutorials/04_cubes_and_objects/08_drive_to_charger_test.py
@@ -51,7 +51,7 @@ def drive_to_charger(robot):
 
     # see if Cozmo already knows where the charger is
     if robot.world.charger:
-        if robot.world.charger.pose.origin_id == robot.pose.origin_id:
+        if robot.world.charger.pose.is_comparable(robot.pose):
             print("Cozmo already knows where the charger is!")
             charger = robot.world.charger
         else:

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -55,7 +55,7 @@ from . import event
 from . import lights
 from . import util
 
-from ._clad import _clad_to_engine_iface, _clad_to_game_cozmo, _clad_to_engine_cozmo
+from ._clad import _clad_to_engine_iface, _clad_to_game_cozmo, _clad_to_engine_cozmo, _clad_to_game_anki
 
 
 #: Length of time in seconds to go without receiving an observed event before
@@ -299,10 +299,9 @@ class ObservableObject(ObservableElement):
 
         self.last_observed_robot_timestamp = available_object.lastObservedTimestamp
 
-        self._pose = util.Pose(available_object.pose.x, available_object.pose.y, available_object.pose.z,
-                               q0=available_object.pose.q0, q1=available_object.pose.q1,
-                               q2=available_object.pose.q2, q3=available_object.pose.q3,
-                               origin_id=available_object.pose.originID)
+        self._pose = util.Pose._create_from_clad(available_object.pose)
+        if available_object.poseState == _clad_to_game_anki.PoseState.Unknown:
+            self._pose.invalidate()
 
         self.dispatch_event(EvtObjectAvailable,
                             obj=self,

--- a/src/cozmo/util.py
+++ b/src/cozmo/util.py
@@ -368,6 +368,28 @@ class Pose:
         q0, q1, q2, q3 = self.rotation.q0_q1_q2_q3
         return _clad_to_engine_anki.PoseStruct3d(x, y, z, q0, q1, q2, q3, self.origin_id)
 
+    def invalidate(self):
+        '''Mark this pose as being invalid (unusable)'''
+        self._origin_id = -1
+
+    def is_comparable(self, other_pose):
+        '''Are these two poses comparable.
+
+        Poses are comparable if they're valid and having matching origin IDs.
+
+        Args:
+            other_pose (:class:`cozmo.util.Pose`): The other pose to compare against.
+        Returns:
+            bool: True if the two poses are comparable, False otherwise.
+        '''
+        return (self.is_valid and other_pose.is_valid and
+                (self.origin_id == other_pose.origin_id))
+
+    @property
+    def is_valid(self):
+        '''bool: Returns True if this is a valid, usable pose.'''
+        return self.origin_id >= 0
+
     @property
     def position(self):
         ''':class:`cozmo.util.Position`: The position component of this pose.'''


### PR DESCRIPTION
When receiving object info on connection - poses where PoseState is unknown are always invalid and should just be ignored.
Added support to Util.Pose for tracking validity.
Updated 08_drive_to_charger_test to show usage.