### PR TITLE
COZMO-9860 Fix occasional failure to scale TkView window at start

### DIFF
--- a/src/cozmo/tkview.py
+++ b/src/cozmo/tkview.py
@@ -130,7 +130,6 @@ class TkImageViewer(tkinter.Frame, TkThreadable):
     def image_event(self, evt, *, image, **kw):
         if self._first_image or self.width is None:
             img = image.annotate_image(scale=self.scale)
-            self._first_image = False
         else:
             img = image.annotate_image(fit_size=(self.width, self.height))
         self._img_queue.append(img)
@@ -150,6 +149,7 @@ class TkImageViewer(tkinter.Frame, TkThreadable):
             # no new image
             return
 
+        self._first_image = False
         photoImage = ImageTk.PhotoImage(image)
 
         self.label.configure(image=photoImage)


### PR DESCRIPTION
There was a race condition where if >1 image_event occurred before _draw_frame was called, the scale wouldn’t be applied to a rendered image and the window would never scale.
This change ensures that we keep applying the scale (instead of fitting to the window) until an image has been displayed (which should allow the scale to resize the window)