### PR TITLE
COZMO-9686 Fix rare exception from aborting a just-completed action

### DIFF
--- a/src/cozmo/action.py
+++ b/src/cozmo/action.py
@@ -105,6 +105,7 @@ class Action(event.Dispatcher):
         self._failure_code = None
         self._failure_reason = None
         self._completed_event = None
+        self._completed_event_pending = False
 
     def __repr__(self):
         extra = self._repr_values()
@@ -126,6 +127,7 @@ class Action(event.Dispatcher):
 
     def _set_completed(self, msg):
         self._state = ACTION_SUCCEEDED
+        self._completed_event_pending = False
         self._dispatch_completed_event(msg)
 
     def _dispatch_completed_event(self, msg):
@@ -139,6 +141,7 @@ class Action(event.Dispatcher):
         self._state = ACTION_FAILED
         self._failure_code = code
         self._failure_reason = reason
+        self._completed_event_pending = False
         self._completed_event = EvtActionCompleted(action=self, state=self._state,
                                               failure_code=code,
                                               failure_reason=reason)
@@ -426,6 +429,9 @@ class _ActionDispatcher(event.Dispatcher):
                 action_id_type = self._action_id_type(action_id)
                 logger.error('Received completed action message for sdk-known %s action_id=%s (was_aborted=%s)',
                              action_id_type, action_id, was_aborted)
+
+        action._completed_event_pending = True
+
         if was_aborted:
             if action._enable_abort_logging:
                 logger.debug('Received completed action message for aborted action=%s', action)
@@ -442,13 +448,22 @@ class _ActionDispatcher(event.Dispatcher):
         # message back in the next engine tick, and can basically be considered
         # cancelled from now.
         action._set_aborting()
-        # move from in-progress to aborting dicts
-        self._aborting[action._action_id] = action
-        del self._in_progress[action._action_id]
 
-        msg = _clad_to_engine_iface.CancelActionByIdTag(idTag=action._action_id,
-                                                        robotID=self.robot.robot_id)
-        self.robot.conn.send_msg(msg)
+        if action._completed_event_pending:
+            # The action was marked as still running but the ActionDispatcher
+            # has already received a completion message (and removed it from
+            # _in_progress) - the action is just waiting to receive a
+            # robot_completed_action message that is still being dispatched
+            # via asyncio.ensure_future
+            logger.debug('Not sending abort for action=%s to engine as it just completed', action)
+        else:
+            # move from in-progress to aborting dicts
+            self._aborting[action._action_id] = action
+            del self._in_progress[action._action_id]
+
+            msg = _clad_to_engine_iface.CancelActionByIdTag(idTag=action._action_id,
+                                                            robotID=self.robot.robot_id)
+            self.robot.conn.send_msg(msg)
 
     def _abort_all_actions(self):
         # Mark any in-progress actions as aborting - they should get a "Cancelled"

--- a/src/cozmo/anim.py
+++ b/src/cozmo/anim.py
@@ -62,6 +62,12 @@ class Animation(action.Action):
         return _clad_to_engine_iface.PlayAnimation(
             robotID=self.robot.robot_id, animationName=self.anim_name, numLoops=self.loop_count)
 
+    def _dispatch_completed_event(self, msg):
+        self._completed_event = EvtAnimationCompleted(
+                action=self, state=self._state,
+                animation_name=self.anim_name)
+        self.dispatch_event(self._completed_event)
+
 
 class AnimationTrigger(action.Action):
     '''An AnimationTrigger represents a playing animation trigger.
@@ -89,10 +95,10 @@ class AnimationTrigger(action.Action):
             robotID=self.robot.robot_id, trigger=self.trigger.id, numLoops=self.loop_count)
 
     def _dispatch_completed_event(self, msg):
-        self.dispatch_event(EvtAnimationCompleted,
+        self._completed_event = EvtAnimationCompleted(
                 action=self, state=self._state,
                 animation_name=self.trigger.name)
-
+        self.dispatch_event(self._completed_event)
 
 
 class AnimationNames(event.Dispatcher, set):


### PR DESCRIPTION
Aborting an action that just completed (but didn’t yet receive the event to update from running to complete) no longer results in an exception but now gracefully does nothing.
AnimationTrigger class now correctly caches and returns completed event in the case of WaitForCompleted() being called when already complete
Animation class now behaves like AnimationTrigger in dispatching EvtAnimationCompleted on completion instead of base Action’s event