### PR TITLE
COZMO-9128 Camera properties and exposure controls

### DIFF
--- a/examples/tutorials/03_vision/04_exposure.py
+++ b/examples/tutorials/03_vision/04_exposure.py
@@ -16,7 +16,7 @@
 
 '''Demonstrate the manual and auto exposure settings of Cozmo's camera.
 
-This example demonstrates the use of auto-exposure and manual-exposure for
+This example demonstrates the use of auto exposure and manual exposure for
 Cozmo's camera. The current camera settings are overlayed onto the camera
 viewer window.
 '''
@@ -34,12 +34,13 @@ except ImportError:
 import cozmo
 
 
-# A global string value to display in the window to make it more obvious
-# what the example program is currently doing.
+# A global string value to display in the camera viewer window to make it more
+# obvious what the example program is currently doing.
 example_mode = ""
 
 
-# An annotator for live-display of all of the camera info
+# An annotator for live-display of all of the camera info on top of the camera
+# viewer window.
 @cozmo.annotate.annotator
 def camera_info(image, scale, annotator=None, world=None, **kw):
     d = ImageDraw.Draw(image)
@@ -76,7 +77,7 @@ def cozmo_program(robot: cozmo.robot.Robot):
     global example_mode
     robot.world.image_annotator.add_annotator('camera_info', camera_info)
 
-    # Ensure camera is in auto-exposure, demo for 5 seconds
+    # Ensure camera is in auto exposure mode and demonstrate auto exposure for 5 seconds
     robot.enable_auto_exposure()
     example_mode = "Auto Exposure"
     time.sleep(5)
@@ -87,19 +88,19 @@ def cozmo_program(robot: cozmo.robot.Robot):
     auto_exposure_ms = cam.exposure_ms
     auto_gain = cam.camera_gain
 
-    # Demonstrate Manual Exposure, linearly increasing the exposure time
+    # Demonstrate manual exposure, linearly increasing the exposure time
     example_mode = "Manual Exposure - Increasing Exposure, Fixed Gain"
     for exposure in range(cam.min_exposure_time_ms, cam.max_exposure_time_ms+1, 1):
         robot.set_manual_exposure(exposure, auto_gain)
         time.sleep(0.1)
 
-    # Demonstrate Manual Exposure, linearly increasing the gain
+    # Demonstrate manual exposure, linearly increasing the gain
     example_mode = "Manual Exposure - Increasing Gain, Fixed Exposure"
     for gain in np.arange(cam.min_camera_gain, cam.max_camera_gain, 0.05):
         robot.set_manual_exposure(auto_exposure_ms, gain)
         time.sleep(0.1)
 
-    # Switch back to Auto Exposure, demo for a final 5 seconds and then exit
+    # Switch back to auto exposure, demo for a final 5 seconds and then exit
     robot.enable_auto_exposure()
     example_mode = "Mode: Auto Exposure"
     time.sleep(5)

--- a/examples/tutorials/03_vision/04_exposure.py
+++ b/examples/tutorials/03_vision/04_exposure.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2017 Anki, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the file LICENSE.txt or at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''Demonstrate the manual and auto exposure settings of Cozmo's camera.
+
+This example demonstrates the use of auto-exposure and manual-exposure for
+Cozmo's camera. The current camera settings are overlayed onto the camera
+viewer window.
+'''
+
+
+import sys
+import time
+
+try:
+    from PIL import ImageDraw, ImageFont
+    import numpy as np
+except ImportError:
+    sys.exit('run `pip3 install --user Pillow numpy` to run this example')
+
+import cozmo
+
+
+# A global string value to display in the window to make it more obvious
+# what the example program is currently doing.
+example_mode = ""
+
+
+# An annotator for live-display of all of the camera info
+@cozmo.annotate.annotator
+def camera_info(image, scale, annotator=None, world=None, **kw):
+    d = ImageDraw.Draw(image)
+    bounds = [3, 0, image.width, image.height]
+
+    camera_config = world.robot.camera_config
+    text_to_display = "Example Mode: " + example_mode + "\n\n"
+    text_to_display += "Fixed Camera Settings (Calibrated for this Robot):\n\n"
+    text_to_display += 'focal_length: %s\n' % camera_config.focal_length
+    text_to_display += 'center: %s\n' % camera_config.center
+    text_to_display += 'fov: <%.3f, %.3f> degrees\n' % (camera_config.fov_x.degrees,
+                                                        camera_config.fov_y.degrees)
+    text_to_display += "\n"
+    text_to_display += "Valid exposure and gain ranges:\n\n"
+    text_to_display += 'exposure: %s..%s\n' % (camera_config.min_exposure_time_ms,
+                                               camera_config.max_exposure_time_ms)
+    text_to_display += 'gain: %.3f..%.3f\n' % (camera_config.min_camera_gain,
+                                               camera_config.max_camera_gain)
+    text_to_display += "\n"
+    text_to_display += "Current settings:\n\n"
+    text_to_display += 'Auto Exposure Enabled: %s\n' % camera_config.is_auto_exposure_enabled
+    text_to_display += 'Exposure: %s ms\n' % camera_config.exposure_ms
+    text_to_display += 'Gain: %.3f\n' % camera_config.camera_gain
+
+    text = cozmo.annotate.ImageText(text_to_display,
+                                    position=cozmo.annotate.TOP_LEFT,
+                                    line_spacing=2,
+                                    color="white",
+                                    outline_color="black", full_outline=True)
+    text.render(d, bounds)
+
+
+def cozmo_program(robot: cozmo.robot.Robot):
+    global example_mode
+    robot.world.image_annotator.add_annotator('camera_info', camera_info)
+
+    # Ensure camera is in auto-exposure, demo for 5 seconds
+    robot.enable_auto_exposure()
+    example_mode = "Auto Exposure"
+    time.sleep(5)
+
+    # Grab the current auto exposure/gain values as good defaults for
+    # the current lighting conditions
+    cam = robot.camera_config
+    auto_exposure_ms = cam.exposure_ms
+    auto_gain = cam.camera_gain
+
+    # Demonstrate Manual Exposure, linearly increasing the exposure time
+    example_mode = "Manual Exposure - Increasing Exposure, Fixed Gain"
+    for exposure in range(cam.min_exposure_time_ms, cam.max_exposure_time_ms+1, 1):
+        robot.set_manual_exposure(exposure, auto_gain)
+        time.sleep(0.1)
+
+    # Demonstrate Manual Exposure, linearly increasing the gain
+    example_mode = "Manual Exposure - Increasing Gain, Fixed Exposure"
+    for gain in np.arange(cam.min_camera_gain, cam.max_camera_gain, 0.05):
+        robot.set_manual_exposure(auto_exposure_ms, gain)
+        time.sleep(0.1)
+
+    # Switch back to Auto Exposure, demo for a final 5 seconds and then exit
+    robot.enable_auto_exposure()
+    example_mode = "Mode: Auto Exposure"
+    time.sleep(5)
+
+
+cozmo.run_program(cozmo_program, use_viewer=True, force_viewer_on_top=True)

--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 Anki, Inc.
+# Copyright (c) 2016-2017 Anki, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -81,6 +81,7 @@ FORCED_ROBOT_MESSAGES = {"AnimationAborted",
                          "CarryStateUpdate",
                          "ChargerEvent",
                          "CubeLightsStateTransition",
+                         "CurrentCameraParams",
                          "LoadedKnownFace",
                          "ObjectProjectsIntoFOV",
                          "ObjectStates",

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 Anki, Inc.
+# Copyright (c) 2016-2017 Anki, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ methods such as :meth:`~cozmo.event.Dispatcher.wait_for` and
 # __all__ should order by constants, event classes, other classes, functions.
 __all__ = ['MAX_HEAD_ANGLE', 'MIN_HEAD_ANGLE', 'MIN_LIFT_HEIGHT_MM', 'MAX_LIFT_HEIGHT_MM',
            'EvtRobotReady',
-           'GoToPose', 'DisplayOledFaceImage', 'DriveOffChargerContacts',
+           'CameraConfig', 'GoToPose', 'DisplayOledFaceImage', 'DriveOffChargerContacts',
            'DriveStraight', 'PickupObject', 'PlaceOnObject',
            'PlaceObjectOnGroundHere', 'SayText', 'SetHeadAngle',
            'SetLiftHeight', 'TurnInPlace', 'TurnTowardsFace',
@@ -443,6 +443,127 @@ class PerformOffChargerContext(event.Dispatcher):
         return False
 
 
+class CameraConfig:
+    """The fixed properties and current settings for Cozmo's Camera
+
+    A full 3x3 calibration matrix for doing 3D reasoning based on the camera
+    images would look like:
+
+        +--------------+--------------+---------------+
+        |focal_length.x|      0       |    center.x   |
+        +--------------+--------------+---------------+
+        |       0      |focal_length.y|    center.y   |
+        +--------------+--------------+---------------+
+        |       0      |       0      |        1      |
+        +--------------+--------------+---------------+
+    """
+
+    def __init__(self,
+                 focal_length_x: float,
+                 focal_length_y: float,
+                 center_x: float,
+                 center_y: float,
+                 fov_x_degrees: float,
+                 fov_y_degrees: float,
+                 min_exposure_time_ms: int,
+                 max_exposure_time_ms: int,
+                 min_camera_gain: float,
+                 max_camera_gain: float):
+        self._focal_length = util.Vector2(focal_length_x, focal_length_y)
+        self._center = util.Vector2(center_x, center_y)
+        self._fov_x = util.degrees(fov_x_degrees)
+        self._fov_y = util.degrees(fov_y_degrees)
+        self._min_exposure_time_ms = min_exposure_time_ms
+        self._max_exposure_time_ms = max_exposure_time_ms
+        self._min_camera_gain = min_camera_gain
+        self._max_camera_gain = max_camera_gain
+        self._camera_gain = 0.0
+        self._exposure_ms = 0
+        self._auto_exposure_enabled = True
+
+    @classmethod
+    def _create_from_clad(cls, cs):
+        return cls(cs.focalLengthX, cs.focalLengthY,
+                   cs.centerX, cs.centerY,
+                   cs.fovX, cs.fovY,
+                   cs.minCameraExposureTime_ms, cs.maxCameraExposureTime_ms,
+                   cs.minCameraGain, cs.maxCameraGain)
+
+    def _update_params(self, camera_gain, exposure_ms, auto_exposure_enabled):
+        self._camera_gain = camera_gain
+        self._exposure_ms = exposure_ms
+        self._auto_exposure_enabled = auto_exposure_enabled
+
+    # Fixed camera properties (calibrated for each robot at the factory).
+
+    @property
+    def focal_length(self):
+        ''':class:`cozmo.util.Vector2`:  The focal length of the camera.
+
+        This is focal length combined with pixel skew (as the pixels aren't
+        perfectly square), so there are subtly different values for x and y.
+        '''
+        return self._focal_length
+
+    @property
+    def center(self):
+        ''':class:`cozmo.util.Vector2`:  The focal center of the camera.'''
+        return self._center
+
+    @property
+    def fov_x(self):
+        ''':class:`cozmo.util.Angle`: The x (horizontal) field of view.'''
+        return self._fov_x
+
+    @property
+    def fov_y(self):
+        ''':class:`cozmo.util.Angle`: The y (vertical) field of view.'''
+        return self._fov_y
+
+    # The fixed range of values supported for this camera.
+
+    @property
+    def min_exposure_time_ms(self):
+        '''int: The minimum supported exposure time in milliseconds.'''
+        return self._min_exposure_time_ms
+
+    @property
+    def max_exposure_time_ms(self):
+        '''int: The maximum supported exposure time in milliseconds.'''
+        return self._max_exposure_time_ms
+
+    @property
+    def min_camera_gain(self):
+        '''float: The minimum supported camera gain.'''
+        return self._min_camera_gain
+
+    @property
+    def max_camera_gain(self):
+        '''float: The maximum supported camera gain.'''
+        return self._max_camera_gain
+
+    # The current camera exposure/gain settings, these update live.
+
+    @property
+    def is_auto_exposure_enabled(self):
+        '''bool: True if auto exposure is currently enabled
+
+        If auto exposure is enabled the `camera_gain` and `exposure_ms`
+        values will constantly be updated by Cozmo.
+        '''
+        return self._auto_exposure_enabled
+
+    @property
+    def camera_gain(self):
+        '''float: The current camera gain setting.'''
+        return self._camera_gain
+
+    @property
+    def exposure_ms(self):
+        '''int: The current camera exposure setting in milliseconds.'''
+        return self._exposure_ms
+
+
 class Robot(event.Dispatcher):
     """The interface to a Cozmo robot.
 
@@ -613,6 +734,12 @@ class Robot(event.Dispatcher):
         self._robot_status_flags = 0
         self._game_status_flags = 0
 
+        self._serial_number_head = 0
+        self._serial_number_body = 0
+        self._model_number = 0
+        self._hw_version = 0
+
+        self._camera_config = None  # type: CameraConfig
 
         # send all received events to the world and action dispatcher
         self._add_child_dispatcher(self._action_dispatcher)
@@ -642,7 +769,7 @@ class Robot(event.Dispatcher):
             self.conn.send_msg(msg)
 
             self._is_ready = True
-            logger.info("Robot initialized OK")
+            logger.info('Robot id=%s serial=%s initialized OK', self.robot_id, self.serial)
             self.dispatch_event(EvtRobotReady, robot=self)
         asyncio.ensure_future(_init(), loop=self._loop)
 
@@ -803,6 +930,19 @@ class Robot(event.Dispatcher):
         '''bool: True if Cozmo has any SDK-triggered actions still in progress.'''
         return self._action_dispatcher.has_in_progress_actions
 
+    @property
+    def camera_config(self):
+        ''':class:`cozmo.robot.CameraConfig`: The read-only config/calibration for this robot's camera'''
+        return self._camera_config
+
+    @property
+    def serial(self):
+        '''string: The serial number, as a hex-string, for the robot.
+
+        This matches the Cozmo Serial value in the settings menu of the app.
+        '''
+        return "%08x" % self._serial_number_body
+
     #### Private Event Handlers ####
 
     #def _recv_default_handler(self, event, **kw):
@@ -817,6 +957,17 @@ class Robot(event.Dispatcher):
 
     def _recv_msg_image_chunk(self, evt, *, msg):
         self.camera.dispatch_event(evt)
+
+    def _recv_msg_per_robot_settings(self, evt, *, msg):
+        self._serial_number_head = msg.serialNumberHead
+        self._serial_number_body = msg.serialNumberBody
+        self._model_number = msg.modelNumber
+        self._hw_version = msg.hwVersion
+        self._camera_config = CameraConfig._create_from_clad(msg.cameraConfig)
+
+    def _recv_msg_current_camera_params(self, evt, *, msg):
+        if self._camera_config is not None:
+            self._camera_config._update_params(msg.cameraGain, msg.exposure_ms, msg.autoExposureEnabled)
 
     def _recv_msg_robot_state(self, evt, *, msg):
         self._pose = util.Pose(x=msg.pose.x, y=msg.pose.y, z=msg.pose.z,
@@ -888,6 +1039,54 @@ class Robot(event.Dispatcher):
         msg = _clad_to_engine_iface.EnableVisionMode(
             mode=_clad_to_engine_cozmo.VisionMode.EstimatingFacialExpression,
             enable=enable)
+        self.conn.send_msg(msg)
+
+    ### Camera Commands ###
+
+    def enable_auto_exposure(self):
+        '''Enable auto exposure on Cozmo's Camera.
+
+        Enable auto exposure on Cozmo's camera to constantly update the exposure
+        time and gain values based on the recent images. This is the default mode
+        when any SDK program starts.
+        '''
+        msg = _clad_to_engine_iface.SetCameraSettings(enableAutoExposure=True)
+        self.conn.send_msg(msg)
+
+    def set_manual_exposure(self, exposure_ms, gain):
+        '''Set manual exposure values for Cozmo's Camera.
+
+        Disable auto exposure on Cozmo's camera and force the specified exposure
+        time and gain values.
+
+        Args:
+            exposure_ms (int): The desired exposure time in milliseconds.
+                Must be within the robot's
+                :attr:`~cozmo.robot.Robot.camera_config` exposure range from
+                :attr:`~cozmo.robot.CameraConfig.min_exposure_time_ms` to
+                :attr:`~cozmo.robot.CameraConfig.max_exposure_time_ms`
+            gain (float): The desired gain value.
+                Must be within the robot's
+                :attr:`~cozmo.robot.Robot.camera_config` gain range from
+                :attr:`~cozmo.robot.CameraConfig.min_camera_gain` to
+                :attr:`~cozmo.robot.CameraConfig.max_camera_gain`
+
+        Raises:
+            :class:`ValueError` if supplied an out-of-range exposure or gain.
+        '''
+        cam = self.camera_config
+
+        if (exposure_ms < cam.min_exposure_time_ms) or (exposure_ms > cam.max_exposure_time_ms):
+            raise ValueError('exposure_ms %s out of range %s..%s' %
+                             (exposure_ms, cam.min_exposure_time_ms, cam.max_exposure_time_ms))
+
+        if (gain < cam.min_camera_gain) or (gain > cam.max_camera_gain):
+            raise ValueError('gain %s out of range %s..%s' %
+                             (gain, cam.min_camera_gain, cam.max_camera_gain))
+
+        msg = _clad_to_engine_iface.SetCameraSettings(enableAutoExposure=False,
+                                                      exposure_ms=exposure_ms,
+                                                      gain=gain)
         self.conn.send_msg(msg)
 
     ### Low-Level Commands ###

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -498,16 +498,23 @@ class CameraConfig:
 
     @property
     def focal_length(self):
-        ''':class:`cozmo.util.Vector2`:  The focal length of the camera.
+        ''':class:`cozmo.util.Vector2`: The focal length of the camera.
 
         This is focal length combined with pixel skew (as the pixels aren't
         perfectly square), so there are subtly different values for x and y.
+        It is in floating point pixel values e.g. <288.87, 288.36>.
         '''
         return self._focal_length
 
     @property
     def center(self):
-        ''':class:`cozmo.util.Vector2`:  The focal center of the camera.'''
+        ''':class:`cozmo.util.Vector2`: The focal center of the camera.
+
+        This is the position of the optical center of projection within the
+        image. It will be close to the center of the image, but adjusted based
+        on the calibration of the lens at the factory. It is in floating point
+        pixel values e.g. <155.11, 111.40>.
+        '''
         return self._center
 
     @property

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -937,9 +937,10 @@ class Robot(event.Dispatcher):
 
     @property
     def serial(self):
-        '''string: The serial number, as a hex-string, for the robot.
+        '''string: The serial number, as a hex-string (e.g "02e08032"), for the robot.
 
-        This matches the Cozmo Serial value in the settings menu of the app.
+        This matches the Cozmo Serial value in the About section of the settings
+        menu in the app.
         '''
         return "%08x" % self._serial_number_body
 

--- a/src/cozmo/util.py
+++ b/src/cozmo/util.py
@@ -25,7 +25,7 @@ __all__ = ['Angle', 'degrees', 'radians',
            'Rotation', 'rotation_quaternion', 'rotation_z_angle',
            'angle_z_to_quaternion',
            'Speed', 'speed_mmps',
-           'Timeout']
+           'Timeout', 'Vector2', 'Vector3']
 
 
 import collections
@@ -535,6 +535,59 @@ def angle_z_to_quaternion(angle_z):
     # q3 = cos(x/2)*cos(y/2)*sin(z/2) - sin(x/2)*sin(y/2)*cos(z/2)
     q3 = math.sin(angle_z.radians/2)
     return q0,q1,q2,q3
+
+
+class Vector2:
+    '''Represents a 2D Vector (type/units aren't specified)
+
+    Args:
+        x (float): X component
+        y (float): Y component
+    '''
+
+    __slots__ = ('_x', '_y')
+
+    def __init__(self, x, y):
+        self._x = x
+        self._y = y
+
+    @property
+    def x(self):
+        '''float: The x component.'''
+        return self._x
+
+    @property
+    def y(self):
+        '''float: The y component.'''
+        return self._y
+
+    @property
+    def x_y(self):
+        '''tuple (float, float): The X, Y elements of the Vector2 (x,y)'''
+        return self._x, self._y
+
+    def __repr__(self):
+        return "<%s x: %.2f y: %.2f>" % (self.__class__.__name__, self.x, self.y)
+
+    def __add__(self, other):
+        if not isinstance(other, Vector2):
+            raise TypeError("Unsupported operand for + expected Vector2")
+        return Vector2(self.x + other.x, self.y + other.y)
+
+    def __sub__(self, other):
+        if not isinstance(other, Vector2):
+            raise TypeError("Unsupported operand for - expected Vector2")
+        return Vector2(self.x - other.x, self.y - other.y)
+
+    def __mul__(self, other):
+        if not isinstance(other, (int, float)):
+            raise TypeError("Unsupported operand for * expected number")
+        return Vector2(self.x * other, self.y * other)
+
+    def __truediv__(self, other):
+        if not isinstance(other, (int, float)):
+            raise TypeError("Unsupported operand for / expected number")
+        return Vector2(self.x / other, self.y / other)
 
 
 class Vector3:


### PR DESCRIPTION
Added a Vector2 helper class (like Vector3, but without the z component)
Added a CameraConfig class to robot for keeping track of camera properties and settings
On connection SDK programs now immediately receive a number of per-robot settings, includes serial number and camera calibration.
Camera Exposure can now be override manually.
Current exposure and gain values are streamed back to SDK from Engine as they’re updated.
Added a tutorial example that shows exposure settings in action
Expanded annotation system slightly to make it support outlined/shadowed text, and line-spacing overrides.