### PR TITLE
COZMO-7787 Expose the result of an Action more clearly.

### DIFF
--- a/examples/tutorials/04_cubes_and_objects/05_cube_stack.py
+++ b/examples/tutorials/04_cubes_and_objects/05_cube_stack.py
@@ -25,26 +25,34 @@ import cozmo
 
 
 def cozmo_program(robot: cozmo.robot.Robot):
+    # Attempt to stack 2 cubes
+
+    # Lookaround until Cozmo knows where at least 2 cubes are:
     lookaround = robot.start_behavior(cozmo.behavior.BehaviorTypes.LookAroundInPlace)
-
     cubes = robot.world.wait_until_observe_num_objects(num=2, object_type=cozmo.objects.LightCube, timeout=60)
-
     lookaround.stop()
 
     if len(cubes) < 2:
         print("Error: need 2 Cubes but only found", len(cubes), "Cube(s)")
     else:
-        current_action = robot.pickup_object(cubes[0])
+        # Try and pickup the 1st cube
+        current_action = robot.pickup_object(cubes[0], num_retries=3)
         current_action.wait_for_completed()
         if current_action.has_failed:
             code, reason = current_action.failure_reason
-            print("Pickup Cube failed: code=%s reason=%s" % (code, reason))
+            result = current_action.result
+            print("Pickup Cube failed: code=%s reason='%s' result=%s" % (code, reason, result))
+            return
 
-        current_action = robot.place_on_object(cubes[1])
+        # Now try to place that cube on the 2nd one
+        current_action = robot.place_on_object(cubes[1], num_retries=3)
         current_action.wait_for_completed()
         if current_action.has_failed:
             code, reason = current_action.failure_reason
-            print("Place On Cube failed: code=%s reason=%s" % (code, reason))
+            result = current_action.result
+            print("Place On Cube failed: code=%s reason='%s' result=%s" % (code, reason, result))
+            return
 
+        print("Cozmo successfully stacked 2 blocks!")
 
 cozmo.run_program(cozmo_program)

--- a/src/cozmo/action.py
+++ b/src/cozmo/action.py
@@ -116,7 +116,7 @@ class ActionResults:
     #: There was a problem with the Pose provided.
     BAD_POSE = _ActionResult("BAD_POSE", _clad_to_game_cozmo.ActionResult.BAD_POSE)
 
-    # (Undocumented) The SDK provided tag was bad (shouldn't occur - would indicate a bug in the SDK)
+    # (Undocumented) The SDK-provided tag was bad (shouldn't occur - would indicate a bug in the SDK)
     BAD_TAG = _ActionResult("BAD_TAG", _clad_to_game_cozmo.ActionResult.BAD_TAG)
 
     # (Undocumented) Shouldn't occur outside of factory
@@ -220,15 +220,15 @@ class ActionResults:
     LAST_PICK_AND_PLACE_FAILED = _ActionResult("LAST_PICK_AND_PLACE_FAILED",
                                                _clad_to_game_cozmo.ActionResult.LAST_PICK_AND_PLACE_FAILED)
 
-    #: The required motor isn't movign so the action cannot complete.
+    #: The required motor isn't moving so the action cannot complete.
     MOTOR_STOPPED_MAKING_PROGRESS = _ActionResult("MOTOR_STOPPED_MAKING_PROGRESS",
                                                 _clad_to_game_cozmo.ActionResult.MOTOR_STOPPED_MAKING_PROGRESS)
 
-    #: Not carrying an object when it was expected, but may suceed if the action is retried.
+    #: Not carrying an object when it was expected, but may succeed if the action is retried.
     NOT_CARRYING_OBJECT_RETRY = _ActionResult("NOT_CARRYING_OBJECT_RETRY",
                                               _clad_to_game_cozmo.ActionResult.NOT_CARRYING_OBJECT_RETRY)
 
-    #: Cozmo was unable to plan a path, but may suceed if the action is retried.
+    #: Cozmo was unable to plan a path, but may succeed if the action is retried.
     PATH_PLANNING_FAILED_RETRY = _ActionResult("PATH_PLANNING_FAILED_RETRY",
                                                _clad_to_game_cozmo.ActionResult.PATH_PLANNING_FAILED_RETRY)
 


### PR DESCRIPTION
Wrapped the ActionResult from CLAD with a documented Python class to more clearly explain the meaning of each result.
Corrected the action documentation to account for in_parallel usage, and how ActionResult relates to that.
Updated cube_stack example to print the result for failed pickup or place actions.