### PR TITLE
COZMO-9810 Turn off cube lights on SDK connection

### DIFF
--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -155,10 +155,16 @@ class World(event.Dispatcher):
             if not cube:
                 logger.error('Received invalid cube objecttype=%s msg=%s', msg.objectType, msg)
                 return
+            is_uninitialized_cube = (cube.object_id == None)
             cube.object_id = msg.objectID
             self._objects[cube.object_id] = cube
             cube._robot = self.robot # XXX this will move if/when we have multi-robot support
             logger.debug('Allocated object_id=%d to light cube %s', msg.objectID, cube)
+            # FIXME Temp band-aid hack for EnableLightStates no longer turning
+            # off cubes after each run (since app version 1.2) - force them off
+            # on connection at startup
+            if is_uninitialized_cube:
+                cube.set_lights_off()
             return cube
 
         elif msg.objectFamily == _clad_to_game_cozmo.ObjectFamily.Charger:


### PR DESCRIPTION
A bug was introduced on the app-side where the EnableLightStates(enable=False) message (which is automatically sent to disable the cube lights on entering SDK mode and at the end of every SDK program) no longer turns off the lights as part of changing the states. This will be resolved for the 1.3 app release, but in the meantime we’ll automatically turn the lights off on cubes when SDK first connects to them each time to avoid cube lights persisting across multiple SDK program runs.