### PR TITLE
COZMO-9710 Add Youtube installation videos into the documentation

### DIFF
--- a/docs/source/adb.rst
+++ b/docs/source/adb.rst
@@ -22,7 +22,7 @@ macOS Installation
 Windows Installation
 ^^^^^^^^^^^^^^^^^^^^
 
-1. In your internet browser, navigate to this `link <https://dl.google.com/android/repository/platform-tools-latest-windows.zip>`_ and download file ``platform-tools-latest-windows.zip`` to your Downloads folder.
+1. In your internet browser, navigate to this `link <https://dl.google.com/android/repository/platform-tools-latest-windows.zip>`__ and download file ``platform-tools-latest-windows.zip`` to your Downloads folder.
 2. Open a File Explorer window to your Downloads folder and see that your downloaded file ``platform-tools-latest-windows.zip`` is there.
 3. Open a new File Explorer window and create a new folder in ``C:\Users\your_name`` named ``Android``. Then, navigate into your new Android folder. You should now be inside folder ``C:\Users\your_name\Android``.
 4. Move the zip file you downloaded in step 1, ``platform-tools-latest-windows.zip``, to your new Android folder at ``C:\Users\your_name\Android``.
@@ -46,7 +46,7 @@ Windows Installation
 Linux Installation
 ^^^^^^^^^^^^^^^^^^
 
-1. In your internet browser, navigate to this `link <https://dl.google.com/android/repository/platform-tools-latest-linux.zip>`_ and download file ``platform-tools-latest-linux.zip``. You may need to accept the license before downloading.
+1. In your internet browser, navigate to this `link <https://dl.google.com/android/repository/platform-tools-latest-linux.zip>`__ and download file ``platform-tools-latest-linux.zip``. You may need to accept the license before downloading.
 2. Navigate to the zip file download location (e.g., ~/Downloads) and extract the files. The files will be extracted to folder ``platform-tools``.
 3. In your home directory, create folder ``android-sdk-linux``::
 

--- a/docs/source/getstarted.rst
+++ b/docs/source/getstarted.rst
@@ -38,6 +38,18 @@ Starting Up the SDK
 Example Programs
 ----------------
 
+^^^^^^^^^^^^^^^^^
+Walkthrough Video
+^^^^^^^^^^^^^^^^^
+
+For your convenience, here is a video detailing the first 8 simple example programs. There is also simple text-based walkthrough of running your first program below that.
+
+.. raw:: html
+
+   <iframe width="690" height="388" src="https://www.youtube.com/embed/YAQ_USpkxgE?rel=0" frameborder="0" allowfullscreen></iframe>
+
+|
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 First Steps - "Hello World"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/getstarted.rst
+++ b/docs/source/getstarted.rst
@@ -42,7 +42,7 @@ Example Programs
 Walkthrough Video
 ^^^^^^^^^^^^^^^^^
 
-For your convenience, here is a video detailing the first 8 simple example programs. There is also simple text-based walkthrough of running your first program below that.
+For your convenience, here is a video detailing the first few simple example programs. You can also find a simple text-based walkthrough of running your first program below.
 
 .. raw:: html
 

--- a/docs/source/install-macos.rst
+++ b/docs/source/install-macos.rst
@@ -12,7 +12,7 @@ This guide provides instructions on installing the Cozmo SDK for computers runni
 Installation Videos
 ^^^^^^^^^^^^^^^^^^^
 
-For your convenience, videos are provided showing the installation steps being followed on a macOS / OS X computer. One using an iOS device, and one using an Android device. There is also full text-based documenation below these.
+For your convenience, videos are provided showing the installation steps being followed on a macOS / OS X computer; one using an iOS device, and one using an Android device. There is also full text-based documentation below these.
 
 .. raw:: html
 

--- a/docs/source/install-macos.rst
+++ b/docs/source/install-macos.rst
@@ -9,6 +9,20 @@ Installation - macOS / OS X
 This guide provides instructions on installing the Cozmo SDK for computers running with a macOS operating system.
 
 ^^^^^^^^^^^^^^^^^^^
+Installation Videos
+^^^^^^^^^^^^^^^^^^^
+
+For your convenience, videos are provided showing the installation steps being followed on a macOS / OS X computer. One using an iOS device, and one using an Android device. There is also full text-based documenation below these.
+
+.. raw:: html
+
+   <iframe width="690" height="388" src="https://www.youtube.com/embed/zNgmUwuHq-M?rel=0" frameborder="0" allowfullscreen></iframe>
+
+   <iframe width="690" height="388" src="https://www.youtube.com/embed/6xWuhOtkfsc?rel=0" frameborder="0" allowfullscreen></iframe>   
+
+|
+
+^^^^^^^^^^^^^^^^^^^
 Python Installation
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/install-windows.rst
+++ b/docs/source/install-windows.rst
@@ -9,6 +9,20 @@ Installation - Windows
 This guide provides instructions on installing the Cozmo SDK for computers running with a Windows operating system.
 
 ^^^^^^^^^^^^^^^^^^^
+Installation Videos
+^^^^^^^^^^^^^^^^^^^
+
+For your convenience, videos are provided showing the installation steps being followed on a Windows computer. One using an iOS device, and one using an Android device. There is also full text-based documenation below these.
+
+.. raw:: html
+
+   <iframe width="690" height="388" src="https://www.youtube.com/embed/gtRS3iqzSuA?rel=0" frameborder="0" allowfullscreen></iframe>
+
+   <iframe width="690" height="388" src="https://www.youtube.com/embed/9TJeK_AEFYo?rel=0" frameborder="0" allowfullscreen></iframe>   
+
+|
+
+^^^^^^^^^^^^^^^^^^^
 Python Installation
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/install-windows.rst
+++ b/docs/source/install-windows.rst
@@ -12,7 +12,7 @@ This guide provides instructions on installing the Cozmo SDK for computers runni
 Installation Videos
 ^^^^^^^^^^^^^^^^^^^
 
-For your convenience, videos are provided showing the installation steps being followed on a Windows computer. One using an iOS device, and one using an Android device. There is also full text-based documenation below these.
+For your convenience, videos are provided showing the installation steps being followed on a Windows computer; one using an iOS device, and one using an Android device. There is also full text-based documentation below these.
 
 .. raw:: html
 


### PR DESCRIPTION
Embedded the 2 mac videos in the macOS page, and the 2 Windows ones to the Windows installation page.
Embedded the basic walkthrough in the get started section
Fixed warning from adb.rst generation (you can’t have 2 links with the same name unless you make them anonymous with a double trailing underscore instead of a single one).