### PR TITLE
COZMO-7787 Include Result in Action string representation

### DIFF
--- a/src/cozmo/action.py
+++ b/src/cozmo/action.py
@@ -328,7 +328,8 @@ class Action(event.Dispatcher):
         if len(extra) > 0:
             extra = ' '+extra
         if self._state == ACTION_FAILED:
-            extra += " failure_reason=%s failure_code=%s" % (self._failure_reason, self._failure_code)
+            extra += (" failure_reason='%s' failure_code=%s result=%s" %
+                      (self._failure_reason, self._failure_code, self.result))
         return '<%s state=%s%s>' % (self.__class__.__name__, self.state, extra)
 
     def _repr_values(self):


### PR DESCRIPTION
Added Action result to the repr if the action failed to give more info on what failed.
Wrapped failure_reason in quotes as the values have spaces in so it's hard to read otherwise.
