### PR TITLE
Mwesley/cozmo 4610 pose state refactor

### DIFF
--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -80,11 +80,12 @@ FORCED_ROBOT_MESSAGES = {"AnimationAborted",
                          "BlockPoolDataMessage",
                          "CarryStateUpdate",
                          "ChargerEvent",
+                         "ConnectedObjectStates",
                          "CubeLightsStateTransition",
                          "CurrentCameraParams",
                          "LoadedKnownFace",
+                         "LocatedObjectStates",
                          "ObjectProjectsIntoFOV",
-                         "ObjectStates",
                          "ReactionaryBehaviorTransition",
                          "RobotChangedObservedFaceID",
                          "RobotCliffEventFinished",
@@ -372,10 +373,16 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
                 'cozmoclad_version=%s app_build_version=%s',
                 version.__version__, cozmoclad.__version__, msg.buildVersion)
 
-        # We send RequestObjectStates before refreshing the animation names
-        # as this ensures that we will receive the responses before we mark the
-        # robot as ready
-        msg = _clad_to_engine_iface.RequestObjectStates()
+        # We send RequestConnectedObjects and RequestLocatedObjectStates before
+        # refreshing the animation names as this ensures that we will receive
+        # the responses before we mark the robot as ready
+        # Request information on connected objects (e.g. the object ID of each cube)
+        # (this won't provide location/pose info)
+        msg = _clad_to_engine_iface.RequestConnectedObjects()
+        self.send_msg(msg)
+        # Request the pose information for all objects whose location we know
+        # (this won't include any objects where the location is currently not known)
+        msg = _clad_to_engine_iface.RequestLocatedObjects()
         self.send_msg(msg)
 
         self.anim_names.refresh()

--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -375,11 +375,13 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
 
         # We send RequestConnectedObjects and RequestLocatedObjectStates before
         # refreshing the animation names as this ensures that we will receive
-        # the responses before we mark the robot as ready
+        # the responses before we mark the robot as ready.
+
         # Request information on connected objects (e.g. the object ID of each cube)
         # (this won't provide location/pose info)
         msg = _clad_to_engine_iface.RequestConnectedObjects()
         self.send_msg(msg)
+
         # Request the pose information for all objects whose location we know
         # (this won't include any objects where the location is currently not known)
         msg = _clad_to_engine_iface.RequestLocatedObjectStates()

--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -382,7 +382,7 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
         self.send_msg(msg)
         # Request the pose information for all objects whose location we know
         # (this won't include any objects where the location is currently not known)
-        msg = _clad_to_engine_iface.RequestLocatedObjects()
+        msg = _clad_to_engine_iface.RequestLocatedObjectStates()
         self.send_msg(msg)
 
         self.anim_names.refresh()

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -38,7 +38,7 @@ online documentation.  They will be detected as :class:`CustomObject` instances.
 
 # __all__ should order by constants, event classes, other classes, functions.
 __all__ = ['LightCube1Id', 'LightCube2Id', 'LightCube3Id', 'OBJECT_VISIBILITY_TIMEOUT',
-           'EvtObjectAppeared', 'EvtObjectConnected', 'EvtObjectLocated, 'EvtObjectTapped',
+           'EvtObjectAppeared', 'EvtObjectConnected', 'EvtObjectLocated', 'EvtObjectTapped',
            'EvtObjectConnectChanged', 'EvtObjectDisappeared', 'EvtObjectObserved',
            'ObservableElement', 'ObservableObject', 'LightCube', 'Charger',
            'CustomObject', 'FixedCustomObject']
@@ -331,7 +331,7 @@ class ObservableObject(ObservableElement):
             # Note Dirty currently means either moved (in which case it's really dirty)
             # or inaccurate (e.g. seen from too far away to give an accurate enough pose for localization)
             # TODO: split Dirty into 2 states, and allow SDK to report the distinction.
-            self._pose.is_accurate = False
+            self._pose._is_accurate = False
 
         self.dispatch_event(EvtObjectLocated,
                             obj=self,

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -38,7 +38,7 @@ online documentation.  They will be detected as :class:`CustomObject` instances.
 
 # __all__ should order by constants, event classes, other classes, functions.
 __all__ = ['LightCube1Id', 'LightCube2Id', 'LightCube3Id', 'OBJECT_VISIBILITY_TIMEOUT',
-           'EvtObjectAppeared', 'EvtObjectAvailable', 'EvtObjectTapped',
+           'EvtObjectAppeared', 'EvtObjectConnected', 'EvtObjectLocated, 'EvtObjectTapped',
            'EvtObjectConnectChanged', 'EvtObjectDisappeared', 'EvtObjectObserved',
            'ObservableElement', 'ObservableObject', 'LightCube', 'Charger',
            'CustomObject', 'FixedCustomObject']
@@ -96,13 +96,24 @@ class EvtObjectAppeared(event.Event):
     pose = 'The cozmo.util.Pose defining the position and rotation of the object'
 
 
-class EvtObjectAvailable(event.Event):
-    '''Triggered when the engine reports that an object is available (i.e. exists).
+class EvtObjectConnected(event.Event):
+    '''Triggered when the engine reports that an object is connected (i.e. exists).
 
     This will usually occur at the start of the program in response to the SDK
-    sending RequestObjectStates to the engine.
+    sending RequestConnectedObjects to the engine.
     '''
-    obj = 'The object that is available'
+    obj = 'The object that is connected'
+    updated = 'A set of field names that have changed'
+    pose = 'The cozmo.util.Pose defining the position and rotation of the object'
+
+
+class EvtObjectLocated(event.Event):
+    '''Triggered when the engine reports that an object is located (i.e. pose is known).
+
+    This will usually occur at the start of the program in response to the SDK
+    sending RequestLocatedObjectStates to the engine.
+    '''
+    obj = 'The object that is located'
     updated = 'A set of field names that have changed'
     pose = 'The cozmo.util.Pose defining the position and rotation of the object'
 
@@ -286,12 +297,25 @@ class ObservableObject(ObservableElement):
     def _dispatch_disappeared_event(self):
         self.dispatch_event(EvtObjectDisappeared, obj=self)
 
-    def _handle_object_state(self, object_state):
-        # triggered when engine sends an ObjectStates message
-        # as a response to a RequestObjectStates message
+    def _handle_connected_object_state(self, object_state):
+        # triggered when engine sends a ConnectedObjectStates message
+        # as a response to a RequestConnectedObjects message
+
+        changed_fields = {'pose'}
+
+        self._pose = util.Pose._create_default()
+
+        self.dispatch_event(EvtObjectConnected,
+                            obj=self,
+                            updated=changed_fields,
+                            pose=self._pose)
+
+    def _handle_located_object_state(self, object_state):
+        # triggered when engine sends a LocatedObjectStates message
+        # as a response to a RequestLocatedObjectStates message
         if (self.last_observed_robot_timestamp and
-                (self.last_observed_robot_timestamp > object_state.lastObservedTimestamp)):
-            logger.debug("ignoring old object_state=%s obj=%s (last_observed_robot_timestamp=%s)",
+            (self.last_observed_robot_timestamp > object_state.lastObservedTimestamp)):
+            logger.warn("Ignoring old located object_state=%s obj=%s (last_observed_robot_timestamp=%s)",
                          object_state, self, self.last_observed_robot_timestamp)
             return
 
@@ -300,10 +324,16 @@ class ObservableObject(ObservableElement):
         self.last_observed_robot_timestamp = object_state.lastObservedTimestamp
 
         self._pose = util.Pose._create_from_clad(object_state.pose)
-        if object_state.poseState == _clad_to_game_anki.PoseState.Unknown:
+        if object_state.poseState == _clad_to_game_anki.PoseState.Invalid:
+            logger.error("Unexpected Invalid pose state received")
             self._pose.invalidate()
+        elif object_state.poseState == _clad_to_game_anki.PoseState.Dirty:
+            # Note Dirty currently means either moved (in which case it's really dirty)
+            # or inaccurate (e.g. seen from too far away to give an accurate enough pose for localization)
+            # TODO: split Dirty into 2 states, and allow SDK to report the distinction.
+            self._pose.is_accurate = False
 
-        self.dispatch_event(EvtObjectAvailable,
+        self.dispatch_event(EvtObjectLocated,
                             obj=self,
                             updated=changed_fields,
                             pose=self._pose)

--- a/src/cozmo/util.py
+++ b/src/cozmo/util.py
@@ -297,7 +297,7 @@ class Pose:
     Only poses of the same origin_id can safely be compared or operated on
     '''
 
-    __slots__ = ('_position', '_rotation', '_origin_id')
+    __slots__ = ('_position', '_rotation', '_origin_id', '_is_accurate')
 
     def __init__(self, x, y, z, q0=None, q1=None, q2=None, q3=None,
                  angle_z=None, origin_id=-1, is_accurate=True):

--- a/src/cozmo/util.py
+++ b/src/cozmo/util.py
@@ -299,16 +299,24 @@ class Pose:
 
     __slots__ = ('_position', '_rotation', '_origin_id')
 
-    def __init__(self, x, y, z, q0=None, q1=None, q2=None, q3=None, angle_z=None, origin_id=0):
+    def __init__(self, x, y, z, q0=None, q1=None, q2=None, q3=None,
+                 angle_z=None, origin_id=-1, is_accurate=True):
         self._position = Position(x,y,z)
         self._rotation = Rotation(q0,q1,q2,q3,angle_z)
         self._origin_id = origin_id
+        self._is_accurate = is_accurate
 
     @classmethod
     def _create_from_clad(cls, pose):
         return cls(pose.x, pose.y, pose.z,
                    q0=pose.q0, q1=pose.q1, q2=pose.q2, q3=pose.q3,
                    origin_id=pose.originID)
+
+    @classmethod
+    def _create_default(cls):
+        return cls(0.0, 0.0, 0.0,
+                   q0=1.0, q1=0.0, q2=0.0, q3=0.0,
+                   origin_id=-1)
 
     def __repr__(self):
         return "<%s %s %s origin_id=%d>" % (self.__class__.__name__, self.position, self.rotation, self.origin_id)
@@ -361,7 +369,7 @@ class Pose:
         res_y = y + math.sin(angle_z.radians)*new_x + math.cos(angle_z.radians)*new_y
         res_z = z + new_z
         res_angle = angle_z + new_angle_z
-        return Pose(res_x, res_y, res_z, angle_z=res_angle)
+        return Pose(res_x, res_y, res_z, angle_z=res_angle, origin_id=self._origin_id)
 
     def encode_pose(self):
         x, y, z = self.position.x_y_z
@@ -411,6 +419,16 @@ class Pose:
         if not isinstance(value, int):
             raise TypeError("The type of origin_id must be int")
         self._origin_id = value
+
+    @property
+    def is_accurate(self):
+        '''bool: Returns True if this pose is valid and accurate.
+
+        Poses are marked as inaccurate if we detect movement via accelerometer,
+        or if they were observed from far enough away that we're less certain
+        of the exact pose.
+        '''
+        return self.is_valid and self._is_accurate
 
 
 def pose_quaternion(x, y, z, q0, q1, q2, q3, origin_id=0):

--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -345,13 +345,44 @@ class World(event.Dispatcher):
             return
         obj.dispatch_event(evt)
 
-    def _recv_msg_object_states(self, evt, *, msg):
+    def _recv_msg_connected_object_states(self, evt, *, msg):
+        # This is received on startup as a response to RequestConnectedObjects
         for object_state in msg.objects:
             obj = self._objects.get(object_state.objectID)
             if not obj:
                 obj = self._allocate_object_from_msg(object_state)
             if obj:
-                obj._handle_object_state(object_state)
+                obj._handle_connected_object_state(object_state)
+
+    def _recv_msg_located_object_states(self, evt, *, msg):
+        # This is received on startup as a response to RequestLocatedObjectStates
+        # It's also automatically sent from Engine whenever poses are rejiggered
+        updated_objects = set()
+        for object_state in msg.objects:
+            obj = self._objects.get(object_state.objectID)
+            if not obj:
+                obj = self._allocate_object_from_msg(object_state)
+            if obj:
+                obj._handle_located_object_state(object_state)
+            updated_objects.add(object_state.objectID)
+        # verify that all objects not received have invalidated poses
+        for id, obj in self._objects.items():
+            if (id not in updated_objects) and obj.pose.is_valid:
+                logger.warn("Object %s still has a valid pose but wasn't part of located_object_state" % obj)
+
+    def _recv_msg_robot_deleted_located_object(self, evt, *, msg):
+        obj = self._objects.get(msg.objectID)
+        if obj is None:
+            logger.warn("Ignoring deleted_located_object for unknown object ID %s" % msg.objectID)
+        else:
+            logger.info("Invalidating pose for deleted located object %s" % obj)
+            obj.pose.invalidate()
+
+    def _recv_msg_robot_delocalized(self, evt, *, msg):
+        # Invalidate the pose for every object
+        logger.info("Robot delocalized - invalidating poses for all objects")
+        for _, obj in self._objects.items():
+            obj.pose.invalidate()
 
     #### Public Event Handlers ####
 
@@ -573,14 +604,6 @@ class World(event.Dispatcher):
         msg = _clad_to_engine_iface.SendAvailableObjects(
                 robotID=self.robot.robot_id, enable=True)
         self.conn.send_msg(msg)
-
-    async def _delete_all_objects(self):
-        # XXX marked this as private as apparently problematic to call
-        # currently as it deletes light cubes too.
-        msg = _clad_to_engine_iface.DeleteAllObjects(robotID=self.robot.robot_id)
-        self.conn.send_msg(msg)
-        await self.wait_for(_clad._MsgRobotDeletedAllObjects)
-        # TODO: reset local object state
 
     async def delete_all_custom_objects(self):
         """Causes the robot to forget about all custom objects it currently knows about."""

--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -346,7 +346,7 @@ class World(event.Dispatcher):
         obj.dispatch_event(evt)
 
     def _recv_msg_connected_object_states(self, evt, *, msg):
-        # This is received on startup as a response to RequestConnectedObjects
+        # This is received on startup as a response to RequestConnectedObjects.
         for object_state in msg.objects:
             obj = self._objects.get(object_state.objectID)
             if not obj:
@@ -355,8 +355,8 @@ class World(event.Dispatcher):
                 obj._handle_connected_object_state(object_state)
 
     def _recv_msg_located_object_states(self, evt, *, msg):
-        # This is received on startup as a response to RequestLocatedObjectStates
-        # It's also automatically sent from Engine whenever poses are rejiggered
+        # This is received on startup as a response to RequestLocatedObjectStates.
+        # It's also automatically sent from Engine whenever poses are rejiggered.
         updated_objects = set()
         for object_state in msg.objects:
             obj = self._objects.get(object_state.objectID)
@@ -368,12 +368,12 @@ class World(event.Dispatcher):
         # verify that all objects not received have invalidated poses
         for id, obj in self._objects.items():
             if (id not in updated_objects) and obj.pose.is_valid:
-                logger.warn("Object %s still has a valid pose but wasn't part of located_object_state" % obj)
+                logger.warn("Object %s still has a valid pose but wasn't part of located_object_state", obj)
 
     def _recv_msg_robot_deleted_located_object(self, evt, *, msg):
         obj = self._objects.get(msg.objectID)
         if obj is None:
-            logger.warn("Ignoring deleted_located_object for unknown object ID %s" % msg.objectID)
+            logger.warn("Ignoring deleted_located_object for unknown object ID %s", msg.objectID)
         else:
             logger.info("Invalidating pose for deleted located object %s" % obj)
             obj.pose.invalidate()
@@ -381,7 +381,7 @@ class World(event.Dispatcher):
     def _recv_msg_robot_delocalized(self, evt, *, msg):
         # Invalidate the pose for every object
         logger.info("Robot delocalized - invalidating poses for all objects")
-        for _, obj in self._objects.items():
+        for obj in self._objects.values():
             obj.pose.invalidate()
 
     #### Public Event Handlers ####


### PR DESCRIPTION
Split ObjectStates into ConnectedObjectStates and LocatedObjectStates
Split RequestObjectStates into RequestConnectedObjects and RequestLocatedObjectStates
Split EvtObjectAvailable into EvtObjectConnected and EvtObjectLocated

Pose now tracks “is_accurate” property (False if pose marked Dirty by engine)
Added default constructor for Pose for an initial invalid Pose on connection
Pose copies origin_id for poses based on other poses
Pose origin_id defaults to -1 (invalid) instead of 0 if not specified.

RobotDelocalized now invalidates all object poses.
RobotDeletedLocatedObject invalidates the pose of that object.

Removed world._delete_all_objects (no longer supported in Engine, and was unused)
