### PR TITLE
COZMO-10283 Fix usage of deprecated methods from SDK

### DIFF
--- a/examples/if_this_then_that/ifttt_gmail.py
+++ b/examples/if_this_then_that/ifttt_gmail.py
@@ -131,7 +131,7 @@ async def serve_gmail(request):
                 robot.display_image_file_on_face("../face_images/ifttt_gmail.png")
 
         except cozmo.RobotBusy:
-            cozmo.logger.warn("Robot was busy so didn't read email address: "+ from_email_address)
+            cozmo.logger.warning("Robot was busy so didn't read email address: "+ from_email_address)
 
     # Perform Cozmo's task in the background so the HTTP server responds immediately.
     asyncio.ensure_future(read_name())

--- a/examples/if_this_then_that/ifttt_sports.py
+++ b/examples/if_this_then_that/ifttt_sports.py
@@ -123,7 +123,7 @@ async def serve_sports(request):
                 robot.display_image_file_on_face("../face_images/ifttt_sports.png")
 
         except cozmo.RobotBusy:
-            cozmo.logger.warn("Robot was busy so didn't read update: '" + alert_body +"'")
+            cozmo.logger.warning("Robot was busy so didn't read update: '" + alert_body +"'")
 
     # Perform Cozmo's task in the background so the HTTP server responds immediately.
     asyncio.ensure_future(read_name())

--- a/examples/if_this_then_that/ifttt_stocks.py
+++ b/examples/if_this_then_that/ifttt_stocks.py
@@ -132,7 +132,7 @@ async def serve_stocks(request):
                 robot.display_image_file_on_face("../face_images/ifttt_stocks.png")
 
         except cozmo.RobotBusy:
-            cozmo.logger.warn("Robot was busy so didn't read stock update: '"+ stock_name + " is up " + percentage + " percent'.")
+            cozmo.logger.warning("Robot was busy so didn't read stock update: '"+ stock_name + " is up " + percentage + " percent'.")
 
     # Perform Cozmo's task in the background so the HTTP server responds immediately.
     asyncio.ensure_future(read_name())

--- a/examples/lib/flask_helpers.py
+++ b/examples/lib/flask_helpers.py
@@ -92,8 +92,10 @@ def serve_pil_image(pil_img, serve_as_jpeg=False, jpeg_quality=70):
     if serve_as_jpeg:
         pil_img.save(img_io, 'JPEG', quality=jpeg_quality)
         img_io.seek(0)
-        return make_uncached_response(send_file(img_io, mimetype='image/jpeg'))
+        return make_uncached_response(send_file(img_io, mimetype='image/jpeg',
+                                                add_etags=False))
     else:
         pil_img.save(img_io, 'PNG')
         img_io.seek(0)
-        return make_uncached_response(send_file(img_io, mimetype='image/png'))
+        return make_uncached_response(send_file(img_io, mimetype='image/png',
+                                                add_etags=False))

--- a/src/cozmo/action.py
+++ b/src/cozmo/action.py
@@ -268,9 +268,9 @@ for (_name, _id) in _clad_to_game_cozmo.ActionResult.__dict__.items():
                     '%s = _ActionResult("%s", _clad_to_game_cozmo.ActionResult.%s)'
                     % (_name, attr.id, _id, _name, _name, _name))
         else:
-            logger.warn('Missing definition for id %s - to document it add:\n'
-                        '%s = _ActionResult("%s", _clad_to_game_cozmo.ActionResult.%s)'
-                        % (_id, _name, _name, _name))
+            logger.warning('Missing definition for id %s - to document it add:\n'
+                           '%s = _ActionResult("%s", _clad_to_game_cozmo.ActionResult.%s)'
+                           % (_id, _name, _name, _name))
             setattr(ActionResults, _name, _ActionResult(_name, _id))
 
 
@@ -440,7 +440,7 @@ class Action(event.Dispatcher):
 
         elif result == types.RUNNING:
             # XXX what does one do with this? it seems to occur after a cancel request!
-            logger.warn('Received "running" action notification for action=%s', self)
+            logger.warning('Received "running" action notification for action=%s', self)
             self._set_failed('running', 'Action was still running')
 
         elif result == types.NOT_STARTED:

--- a/src/cozmo/camera.py
+++ b/src/cozmo/camera.py
@@ -108,7 +108,7 @@ class Camera(event.Dispatcher):
         self._image_stream_enabled = None
         self._color_image_enabled = None
         if np is None:
-            logger.warn("Camera image processing not available due to missng NumPy or Pillow packages: %s" % _img_processing_available)
+            logger.warning("Camera image processing not available due to missng NumPy or Pillow packages: %s" % _img_processing_available)
         else:
             # set property to ensure clad initialization is sent.
             self.image_stream_enabled = False

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -324,7 +324,7 @@ class ObservableObject(ObservableElement):
             # We cannot currently rely on Engine ensuring that object ID remains static
             # E.g. in the case of a cube disconnecting and reconnecting it's removed
             # and then re-added to blockworld which results in a new ID.
-            logger.warn("Changing object_id for %s from %s to %s", self.__class__, self._object_id, value)
+            logger.warning("Changing object_id for %s from %s to %s", self.__class__, self._object_id, value)
         else:
             logger.debug("Setting object_id for %s to %s", self.__class__, value)
         self._object_id = value

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -356,10 +356,10 @@ class SetLiftHeight(action.Action):
         super().__init__(**kw)
 
         if height < 0.0:
-            logger.warning("lift height %s too small, should be in 0..1 range - clamping" % height)
+            logger.warning("lift height %s too small, should be in 0..1 range - clamping", height)
             self.lift_height_mm = MIN_LIFT_HEIGHT_MM
         elif height > 1.0:
-            logger.warning("lift height %s too large, should be in 0..1 range - clamping" % height)
+            logger.warning("lift height %s too large, should be in 0..1 range - clamping", height)
             self.lift_height_mm = MAX_LIFT_HEIGHT_MM
         else:
             self.lift_height_mm = MIN_LIFT_HEIGHT_MM + (height * (MAX_LIFT_HEIGHT_MM - MIN_LIFT_HEIGHT_MM))

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -356,10 +356,10 @@ class SetLiftHeight(action.Action):
         super().__init__(**kw)
 
         if height < 0.0:
-            logger.warn("lift height %s too small, should be in 0..1 range - clamping" % height)
+            logger.warning("lift height %s too small, should be in 0..1 range - clamping" % height)
             self.lift_height_mm = MIN_LIFT_HEIGHT_MM
         elif height > 1.0:
-            logger.warn("lift height %s too large, should be in 0..1 range - clamping" % height)
+            logger.warning("lift height %s too large, should be in 0..1 range - clamping" % height)
             self.lift_height_mm = MAX_LIFT_HEIGHT_MM
         else:
             self.lift_height_mm = MIN_LIFT_HEIGHT_MM + (height * (MAX_LIFT_HEIGHT_MM - MIN_LIFT_HEIGHT_MM))

--- a/src/cozmo/run.py
+++ b/src/cozmo/run.py
@@ -359,7 +359,7 @@ class FirstAvailableConnector(DeviceConnector):
             result = await self._do_connect(self.tcp, *conn_args)
             if not isinstance(result, BaseException):
                 return result
-            logger.warn('No TCP connection found running Cozmo: %s', result)
+            logger.warning('No TCP connection found running Cozmo: %s', result)
 
         android_result = await self._do_connect(self.android, *conn_args)
         if not isinstance(android_result, BaseException):
@@ -369,8 +369,8 @@ class FirstAvailableConnector(DeviceConnector):
         if not isinstance(ios_result, BaseException):
             return ios_result
 
-        logger.warn('No iOS device found running Cozmo: %s', ios_result)
-        logger.warn('No Android device found running Cozmo: %s', android_result)
+        logger.warning('No iOS device found running Cozmo: %s', ios_result)
+        logger.warning('No Android device found running Cozmo: %s', android_result)
 
         raise exceptions.NoDevicesFound('No devices connected running Cozmo in SDK mode')
 

--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -341,7 +341,7 @@ class World(event.Dispatcher):
     def _recv_msg_object_tapped(self, evt, *, msg):
         obj = self._objects.get(msg.objectID)
         if not obj:
-            logger.warn('Tap event received for unknown object ID %s', msg.objectID)
+            logger.warning('Tap event received for unknown object ID %s', msg.objectID)
             return
         obj.dispatch_event(evt)
 


### PR DESCRIPTION
logger.warn is deprecated, replaced all instances with logger.warning
Flask’s send_file complains on 0.11.0 if add_etags is used without a filename, and from 0.12.0 on ignores it, so just set add_etags=False as we don’t require them and there’s no way to specify the filename _and_ a bytesIO object in a way that will use the filename for the tag.