### PR TITLE
COZMO-10267 Moved CameraConfig into Camera

### DIFF
--- a/examples/tutorials/03_vision/04_exposure.py
+++ b/examples/tutorials/03_vision/04_exposure.py
@@ -46,25 +46,25 @@ def camera_info(image, scale, annotator=None, world=None, **kw):
     d = ImageDraw.Draw(image)
     bounds = [3, 0, image.width, image.height]
 
-    cam = world.robot.camera
+    camera = world.robot.camera
     text_to_display = "Example Mode: " + example_mode + "\n\n"
     text_to_display += "Fixed Camera Settings (Calibrated for this Robot):\n\n"
-    text_to_display += 'focal_length: %s\n' % cam.config.focal_length
-    text_to_display += 'center: %s\n' % cam.config.center
-    text_to_display += 'fov: <%.3f, %.3f> degrees\n' % (cam.config.fov_x.degrees,
-                                                        cam.config.fov_y.degrees)
+    text_to_display += 'focal_length: %s\n' % camera.config.focal_length
+    text_to_display += 'center: %s\n' % camera.config.center
+    text_to_display += 'fov: <%.3f, %.3f> degrees\n' % (camera.config.fov_x.degrees,
+                                                        camera.config.fov_y.degrees)
     text_to_display += "\n"
     text_to_display += "Valid exposure and gain ranges:\n\n"
-    text_to_display += 'exposure: %s..%s\n' % (cam.config.min_exposure_time_ms,
-                                               cam.config.max_exposure_time_ms)
-    text_to_display += 'gain: %.3f..%.3f\n' % (cam.config.min_gain,
-                                               cam.config.max_gain)
+    text_to_display += 'exposure: %s..%s\n' % (camera.config.min_exposure_time_ms,
+                                               camera.config.max_exposure_time_ms)
+    text_to_display += 'gain: %.3f..%.3f\n' % (camera.config.min_gain,
+                                               camera.config.max_gain)
     text_to_display += "\n"
     text_to_display += "Current settings:\n\n"
-    text_to_display += 'Auto Exposure Enabled: %s\n' % cam.is_auto_exposure_enabled
-    text_to_display += 'Exposure: %s ms\n' % cam.exposure_ms
-    text_to_display += 'Gain: %.3f\n' % cam.gain
-    color_mode_str = "Color" if cam.color_image_enabled else "Grayscale"
+    text_to_display += 'Auto Exposure Enabled: %s\n' % camera.is_auto_exposure_enabled
+    text_to_display += 'Exposure: %s ms\n' % camera.exposure_ms
+    text_to_display += 'Gain: %.3f\n' % camera.gain
+    color_mode_str = "Color" if camera.color_image_enabled else "Grayscale"
     text_to_display += 'Color Mode: %s\n' % color_mode_str
 
     text = cozmo.annotate.ImageText(text_to_display,
@@ -79,30 +79,30 @@ def demo_camera_exposure(robot: cozmo.robot.Robot):
     global example_mode
 
     # Ensure camera is in auto exposure mode and demonstrate auto exposure for 5 seconds
-    cam = robot.camera
-    cam.enable_auto_exposure()
+    camera = robot.camera
+    camera.enable_auto_exposure()
     example_mode = "Auto Exposure"
     time.sleep(5)
 
     # Grab the current auto exposure/gain values as good defaults for
     # the current lighting conditions
-    auto_exposure_ms = cam.exposure_ms
-    auto_gain = cam.config.min_gain
+    auto_exposure_ms = camera.exposure_ms
+    auto_gain = camera.config.min_gain
 
     # Demonstrate manual exposure, linearly increasing the exposure time
     example_mode = "Manual Exposure - Increasing Exposure, Fixed Gain"
-    for exposure in range(cam.config.min_exposure_time_ms, cam.config.max_exposure_time_ms+1, 1):
-        cam.set_manual_exposure(exposure, auto_gain)
+    for exposure in range(camera.config.min_exposure_time_ms, camera.config.max_exposure_time_ms+1, 1):
+        camera.set_manual_exposure(exposure, auto_gain)
         time.sleep(0.1)
 
     # Demonstrate manual exposure, linearly increasing the gain
     example_mode = "Manual Exposure - Increasing Gain, Fixed Exposure"
-    for gain in np.arange(cam.config.min_gain, cam.config.max_gain, 0.05):
-        cam.set_manual_exposure(auto_exposure_ms, gain)
+    for gain in np.arange(camera.config.min_gain, camera.config.max_gain, 0.05):
+        camera.set_manual_exposure(auto_exposure_ms, gain)
         time.sleep(0.1)
 
     # Switch back to auto exposure, demo for a final 5 seconds and then return
-    cam.enable_auto_exposure()
+    camera.enable_auto_exposure()
     example_mode = "Mode: Auto Exposure"
     time.sleep(5)
 

--- a/examples/tutorials/03_vision/04_exposure.py
+++ b/examples/tutorials/03_vision/04_exposure.py
@@ -46,24 +46,26 @@ def camera_info(image, scale, annotator=None, world=None, **kw):
     d = ImageDraw.Draw(image)
     bounds = [3, 0, image.width, image.height]
 
-    camera_config = world.robot.camera_config
+    cam = world.robot.camera
     text_to_display = "Example Mode: " + example_mode + "\n\n"
     text_to_display += "Fixed Camera Settings (Calibrated for this Robot):\n\n"
-    text_to_display += 'focal_length: %s\n' % camera_config.focal_length
-    text_to_display += 'center: %s\n' % camera_config.center
-    text_to_display += 'fov: <%.3f, %.3f> degrees\n' % (camera_config.fov_x.degrees,
-                                                        camera_config.fov_y.degrees)
+    text_to_display += 'focal_length: %s\n' % cam.config.focal_length
+    text_to_display += 'center: %s\n' % cam.config.center
+    text_to_display += 'fov: <%.3f, %.3f> degrees\n' % (cam.config.fov_x.degrees,
+                                                        cam.config.fov_y.degrees)
     text_to_display += "\n"
     text_to_display += "Valid exposure and gain ranges:\n\n"
-    text_to_display += 'exposure: %s..%s\n' % (camera_config.min_exposure_time_ms,
-                                               camera_config.max_exposure_time_ms)
-    text_to_display += 'gain: %.3f..%.3f\n' % (camera_config.min_camera_gain,
-                                               camera_config.max_camera_gain)
+    text_to_display += 'exposure: %s..%s\n' % (cam.config.min_exposure_time_ms,
+                                               cam.config.max_exposure_time_ms)
+    text_to_display += 'gain: %.3f..%.3f\n' % (cam.config.min_gain,
+                                               cam.config.max_gain)
     text_to_display += "\n"
     text_to_display += "Current settings:\n\n"
-    text_to_display += 'Auto Exposure Enabled: %s\n' % camera_config.is_auto_exposure_enabled
-    text_to_display += 'Exposure: %s ms\n' % camera_config.exposure_ms
-    text_to_display += 'Gain: %.3f\n' % camera_config.camera_gain
+    text_to_display += 'Auto Exposure Enabled: %s\n' % cam.is_auto_exposure_enabled
+    text_to_display += 'Exposure: %s ms\n' % cam.exposure_ms
+    text_to_display += 'Gain: %.3f\n' % cam.gain
+    color_mode_str = "Color" if cam.color_image_enabled else "Grayscale"
+    text_to_display += 'Color Mode: %s\n' % color_mode_str
 
     text = cozmo.annotate.ImageText(text_to_display,
                                     position=cozmo.annotate.TOP_LEFT,
@@ -73,37 +75,48 @@ def camera_info(image, scale, annotator=None, world=None, **kw):
     text.render(d, bounds)
 
 
-def cozmo_program(robot: cozmo.robot.Robot):
+def demo_camera_exposure(robot: cozmo.robot.Robot):
     global example_mode
-    robot.world.image_annotator.add_annotator('camera_info', camera_info)
 
     # Ensure camera is in auto exposure mode and demonstrate auto exposure for 5 seconds
-    robot.enable_auto_exposure()
+    cam = robot.camera
+    cam.enable_auto_exposure()
     example_mode = "Auto Exposure"
     time.sleep(5)
 
     # Grab the current auto exposure/gain values as good defaults for
     # the current lighting conditions
-    cam = robot.camera_config
     auto_exposure_ms = cam.exposure_ms
-    auto_gain = cam.camera_gain
+    auto_gain = cam.config.min_gain
 
     # Demonstrate manual exposure, linearly increasing the exposure time
     example_mode = "Manual Exposure - Increasing Exposure, Fixed Gain"
-    for exposure in range(cam.min_exposure_time_ms, cam.max_exposure_time_ms+1, 1):
-        robot.set_manual_exposure(exposure, auto_gain)
+    for exposure in range(cam.config.min_exposure_time_ms, cam.config.max_exposure_time_ms+1, 1):
+        cam.set_manual_exposure(exposure, auto_gain)
         time.sleep(0.1)
 
     # Demonstrate manual exposure, linearly increasing the gain
     example_mode = "Manual Exposure - Increasing Gain, Fixed Exposure"
-    for gain in np.arange(cam.min_camera_gain, cam.max_camera_gain, 0.05):
-        robot.set_manual_exposure(auto_exposure_ms, gain)
+    for gain in np.arange(cam.config.min_gain, cam.config.max_gain, 0.05):
+        cam.set_manual_exposure(auto_exposure_ms, gain)
         time.sleep(0.1)
 
-    # Switch back to auto exposure, demo for a final 5 seconds and then exit
-    robot.enable_auto_exposure()
+    # Switch back to auto exposure, demo for a final 5 seconds and then return
+    cam.enable_auto_exposure()
     example_mode = "Mode: Auto Exposure"
     time.sleep(5)
+
+
+def cozmo_program(robot: cozmo.robot.Robot):
+    robot.world.image_annotator.add_annotator('camera_info', camera_info)
+
+    # Demo with default grayscale camera images
+    robot.camera.color_image_enabled = False
+    demo_camera_exposure(robot)
+
+    # Demo with color camera images
+    robot.camera.color_image_enabled = True
+    demo_camera_exposure(robot)
 
 
 cozmo.run_program(cozmo_program, use_viewer=True, force_viewer_on_top=True)

--- a/examples/tutorials/03_vision/04_exposure.py
+++ b/examples/tutorials/03_vision/04_exposure.py
@@ -84,21 +84,20 @@ def demo_camera_exposure(robot: cozmo.robot.Robot):
     example_mode = "Auto Exposure"
     time.sleep(5)
 
-    # Grab the current auto exposure/gain values as good defaults for
-    # the current lighting conditions
-    auto_exposure_ms = camera.exposure_ms
-    auto_gain = camera.config.min_gain
-
-    # Demonstrate manual exposure, linearly increasing the exposure time
+    # Demonstrate manual exposure, linearly increasing the exposure time, while
+    # keeping the gain fixed at a medium value.
     example_mode = "Manual Exposure - Increasing Exposure, Fixed Gain"
+    fixed_gain = (camera.config.min_gain + camera.config.max_gain) * 0.5
     for exposure in range(camera.config.min_exposure_time_ms, camera.config.max_exposure_time_ms+1, 1):
-        camera.set_manual_exposure(exposure, auto_gain)
+        camera.set_manual_exposure(exposure, fixed_gain)
         time.sleep(0.1)
 
-    # Demonstrate manual exposure, linearly increasing the gain
+    # Demonstrate manual exposure, linearly increasing the gain, while keeping
+    # the exposure fixed at a relatively low value.
     example_mode = "Manual Exposure - Increasing Gain, Fixed Exposure"
+    fixed_exposure_ms = 10
     for gain in np.arange(camera.config.min_gain, camera.config.max_gain, 0.05):
-        camera.set_manual_exposure(auto_exposure_ms, gain)
+        camera.set_manual_exposure(fixed_exposure_ms, gain)
         time.sleep(0.1)
 
     # Switch back to auto exposure, demo for a final 5 seconds and then return
@@ -119,4 +118,5 @@ def cozmo_program(robot: cozmo.robot.Robot):
     demo_camera_exposure(robot)
 
 
+cozmo.robot.Robot.drive_off_charger_on_connect = False  # Cozmo can stay on his charger for this example
 cozmo.run_program(cozmo_program, use_viewer=True, force_viewer_on_top=True)

--- a/src/cozmo/camera.py
+++ b/src/cozmo/camera.py
@@ -18,7 +18,9 @@ Cozmo has a built-in camera which he uses to observe the world around him.
 
 The :class:`Camera` class defined in this module is made available as
 :attr:`cozmo.world.World.camera` and can be used to enable/disable image
-sending as well as observe raw unprocessed images being sent by the robot.
+sending, enable/disable color images, modify various camera settings,
+read the robot's unique camera calibration settings, as well as observe
+raw unprocessed images being sent by the robot.
 
 Generally, however, it is more useful to observe
 :class:`cozmo.world.EvtNewCameraImage` events, which include the raw camera
@@ -27,7 +29,7 @@ has identified.
 '''
 
 # __all__ should order by constants, event classes, other classes, functions.
-__all__ = ['EvtNewRawCameraImage', 'Camera']
+__all__ = ['EvtNewRawCameraImage', 'CameraConfig', 'Camera']
 
 import functools
 import io
@@ -44,6 +46,7 @@ except ImportError as exc:
 
 from . import event
 from . import logger
+from . import util
 
 from ._clad import _clad_to_engine_iface, _clad_to_engine_cozmo, _clad_to_game_cozmo
 
@@ -87,6 +90,105 @@ class EvtNewRawCameraImage(event.Event):
     image = 'A PIL.Image.Image object'
 
 
+class CameraConfig:
+    """The fixed properties for Cozmo's Camera
+
+    A full 3x3 calibration matrix for doing 3D reasoning based on the camera
+    images would look like:
+
+        +--------------+--------------+---------------+
+        |focal_length.x|      0       |    center.x   |
+        +--------------+--------------+---------------+
+        |       0      |focal_length.y|    center.y   |
+        +--------------+--------------+---------------+
+        |       0      |       0      |        1      |
+        +--------------+--------------+---------------+
+    """
+
+    def __init__(self,
+                 focal_length_x: float,
+                 focal_length_y: float,
+                 center_x: float,
+                 center_y: float,
+                 fov_x_degrees: float,
+                 fov_y_degrees: float,
+                 min_exposure_time_ms: int,
+                 max_exposure_time_ms: int,
+                 min_gain: float,
+                 max_gain: float):
+        self._focal_length = util.Vector2(focal_length_x, focal_length_y)
+        self._center = util.Vector2(center_x, center_y)
+        self._fov_x = util.degrees(fov_x_degrees)
+        self._fov_y = util.degrees(fov_y_degrees)
+        self._min_exposure_time_ms = min_exposure_time_ms
+        self._max_exposure_time_ms = max_exposure_time_ms
+        self._min_gain = min_gain
+        self._max_gain = max_gain
+
+    @classmethod
+    def _create_from_clad(cls, cs):
+        return cls(cs.focalLengthX, cs.focalLengthY,
+                   cs.centerX, cs.centerY,
+                   cs.fovX, cs.fovY,
+                   cs.minCameraExposureTime_ms, cs.maxCameraExposureTime_ms,
+                   cs.minCameraGain, cs.maxCameraGain)
+
+    # Fixed camera properties (calibrated for each robot at the factory).
+
+    @property
+    def focal_length(self):
+        ''':class:`cozmo.util.Vector2`: The focal length of the camera.
+
+        This is focal length combined with pixel skew (as the pixels aren't
+        perfectly square), so there are subtly different values for x and y.
+        It is in floating point pixel values e.g. <288.87, 288.36>.
+        '''
+        return self._focal_length
+
+    @property
+    def center(self):
+        ''':class:`cozmo.util.Vector2`: The focal center of the camera.
+
+        This is the position of the optical center of projection within the
+        image. It will be close to the center of the image, but adjusted based
+        on the calibration of the lens at the factory. It is in floating point
+        pixel values e.g. <155.11, 111.40>.
+        '''
+        return self._center
+
+    @property
+    def fov_x(self):
+        ''':class:`cozmo.util.Angle`: The x (horizontal) field of view.'''
+        return self._fov_x
+
+    @property
+    def fov_y(self):
+        ''':class:`cozmo.util.Angle`: The y (vertical) field of view.'''
+        return self._fov_y
+
+    # The fixed range of values supported for this camera.
+
+    @property
+    def min_exposure_time_ms(self):
+        '''int: The minimum supported exposure time in milliseconds.'''
+        return self._min_exposure_time_ms
+
+    @property
+    def max_exposure_time_ms(self):
+        '''int: The maximum supported exposure time in milliseconds.'''
+        return self._max_exposure_time_ms
+
+    @property
+    def min_gain(self):
+        '''float: The minimum supported camera gain.'''
+        return self._min_gain
+
+    @property
+    def max_gain(self):
+        '''float: The maximum supported camera gain.'''
+        return self._max_gain
+
+
 class Camera(event.Dispatcher):
     '''Represents Cozmo's camera.
 
@@ -107,6 +209,11 @@ class Camera(event.Dispatcher):
         self.robot = robot
         self._image_stream_enabled = None
         self._color_image_enabled = None
+        self._camera_config = None  # type: CameraConfig
+        self._gain = 0.0
+        self._exposure_ms = 0
+        self._auto_exposure_enabled = True
+
         if np is None:
             logger.warning("Camera image processing not available due to missng NumPy or Pillow packages: %s" % _img_processing_available)
         else:
@@ -115,6 +222,51 @@ class Camera(event.Dispatcher):
             self.color_image_enabled = False
         self._reset_partial_state()
 
+    def enable_auto_exposure(self):
+        '''Enable auto exposure on Cozmo's Camera.
+
+        Enable auto exposure on Cozmo's camera to constantly update the exposure
+        time and gain values based on the recent images. This is the default mode
+        when any SDK program starts.
+        '''
+        msg = _clad_to_engine_iface.SetCameraSettings(enableAutoExposure=True)
+        self.robot.conn.send_msg(msg)
+
+    def set_manual_exposure(self, exposure_ms, gain):
+        '''Set manual exposure values for Cozmo's Camera.
+
+        Disable auto exposure on Cozmo's camera and force the specified exposure
+        time and gain values.
+
+        Args:
+            exposure_ms (int): The desired exposure time in milliseconds.
+                Must be within the robot's
+                :attr:`~cozmo.camera.Camera.config` exposure range from
+                :attr:`~cozmo.camera.CameraConfig.min_exposure_time_ms` to
+                :attr:`~cozmo.camera.CameraConfig.max_exposure_time_ms`
+            gain (float): The desired gain value.
+                Must be within the robot's
+                :attr:`~cozmo.camera.Camera.camera_config` gain range from
+                :attr:`~cozmo.camera.CameraConfig.min_gain` to
+                :attr:`~cozmo.camera.CameraConfig.max_gain`
+
+        Raises:
+            :class:`ValueError` if supplied an out-of-range exposure or gain.
+        '''
+        cam = self.config
+
+        if (exposure_ms < cam.min_exposure_time_ms) or (exposure_ms > cam.max_exposure_time_ms):
+            raise ValueError('exposure_ms %s out of range %s..%s' %
+                             (exposure_ms, cam.min_exposure_time_ms, cam.max_exposure_time_ms))
+
+        if (gain < cam.min_gain) or (gain > cam.max_gain):
+            raise ValueError('gain %s out of range %s..%s' %
+                             (gain, cam.min_gain, cam.max_gain))
+
+        msg = _clad_to_engine_iface.SetCameraSettings(enableAutoExposure=False,
+                                                      exposure_ms=exposure_ms,
+                                                      gain=gain)
+        self.robot.conn.send_msg(msg)
 
     #### Private Methods ####
 
@@ -125,6 +277,9 @@ class Camera(event.Dispatcher):
         self._partial_size = 0
         self._partial_metadata = None
         self._last_chunk_id = -1
+
+    def _set_config(self, clad_config):
+        self._config = CameraConfig._create_from_clad(clad_config)
 
     #### Properties ####
 
@@ -175,6 +330,29 @@ class Camera(event.Dispatcher):
         msg = _clad_to_engine_iface.EnableColorImages(enable = enabled)
         self.robot.conn.send_msg(msg)
 
+    @property
+    def config(self):
+        ''':class:`cozmo.camera.CameraConfig`: The read-only config/calibration for the camera'''
+        return self._config
+
+    @property
+    def is_auto_exposure_enabled(self):
+        '''bool: True if auto exposure is currently enabled
+
+        If auto exposure is enabled the `gain` and `exposure_ms`
+        values will constantly be updated by Cozmo.
+        '''
+        return self._auto_exposure_enabled
+
+    @property
+    def gain(self):
+        '''float: The current camera gain setting.'''
+        return self._gain
+
+    @property
+    def exposure_ms(self):
+        '''int: The current camera exposure setting in milliseconds.'''
+        return self._exposure_ms
 
     #### Private Event Handlers ####
 
@@ -217,6 +395,11 @@ class Camera(event.Dispatcher):
         if msg.chunkId == (msg.imageChunkCount - 1):
             self._process_completed_image()
             self._reset_partial_state()
+
+    def _recv_msg_current_camera_params(self, evt, *, msg):
+        self._gain = msg.cameraGain
+        self._exposure_ms = msg.exposure_ms
+        self._auto_exposure_enabled = msg.autoExposureEnabled
 
     def _process_completed_image(self):
         data = self._partial_data[0:self._partial_size]

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -36,14 +36,15 @@ methods such as :meth:`~cozmo.event.Dispatcher.wait_for` and
 # __all__ should order by constants, event classes, other classes, functions.
 __all__ = ['MAX_HEAD_ANGLE', 'MIN_HEAD_ANGLE', 'MIN_LIFT_HEIGHT_MM', 'MAX_LIFT_HEIGHT_MM',
            'EvtRobotReady',
-           'CameraConfig', 'GoToPose', 'DisplayOledFaceImage', 'DriveOffChargerContacts',
-           'DriveStraight', 'PickupObject', 'PlaceOnObject',
+           'GoToPose', 'DisplayOledFaceImage', 'DriveOffChargerContacts',
+           'DriveStraight', 'PerformOffChargerContext', 'PickupObject', 'PlaceOnObject',
            'PlaceObjectOnGroundHere', 'SayText', 'SetHeadAngle',
            'SetLiftHeight', 'TurnInPlace', 'TurnTowardsFace',
            'Robot']
 
 
 import asyncio
+import warnings
 
 from . import logger, logger_protocol
 from . import action
@@ -443,134 +444,6 @@ class PerformOffChargerContext(event.Dispatcher):
         return False
 
 
-class CameraConfig:
-    """The fixed properties and current settings for Cozmo's Camera
-
-    A full 3x3 calibration matrix for doing 3D reasoning based on the camera
-    images would look like:
-
-        +--------------+--------------+---------------+
-        |focal_length.x|      0       |    center.x   |
-        +--------------+--------------+---------------+
-        |       0      |focal_length.y|    center.y   |
-        +--------------+--------------+---------------+
-        |       0      |       0      |        1      |
-        +--------------+--------------+---------------+
-    """
-
-    def __init__(self,
-                 focal_length_x: float,
-                 focal_length_y: float,
-                 center_x: float,
-                 center_y: float,
-                 fov_x_degrees: float,
-                 fov_y_degrees: float,
-                 min_exposure_time_ms: int,
-                 max_exposure_time_ms: int,
-                 min_camera_gain: float,
-                 max_camera_gain: float):
-        self._focal_length = util.Vector2(focal_length_x, focal_length_y)
-        self._center = util.Vector2(center_x, center_y)
-        self._fov_x = util.degrees(fov_x_degrees)
-        self._fov_y = util.degrees(fov_y_degrees)
-        self._min_exposure_time_ms = min_exposure_time_ms
-        self._max_exposure_time_ms = max_exposure_time_ms
-        self._min_camera_gain = min_camera_gain
-        self._max_camera_gain = max_camera_gain
-        self._camera_gain = 0.0
-        self._exposure_ms = 0
-        self._auto_exposure_enabled = True
-
-    @classmethod
-    def _create_from_clad(cls, cs):
-        return cls(cs.focalLengthX, cs.focalLengthY,
-                   cs.centerX, cs.centerY,
-                   cs.fovX, cs.fovY,
-                   cs.minCameraExposureTime_ms, cs.maxCameraExposureTime_ms,
-                   cs.minCameraGain, cs.maxCameraGain)
-
-    def _update_params(self, camera_gain, exposure_ms, auto_exposure_enabled):
-        self._camera_gain = camera_gain
-        self._exposure_ms = exposure_ms
-        self._auto_exposure_enabled = auto_exposure_enabled
-
-    # Fixed camera properties (calibrated for each robot at the factory).
-
-    @property
-    def focal_length(self):
-        ''':class:`cozmo.util.Vector2`: The focal length of the camera.
-
-        This is focal length combined with pixel skew (as the pixels aren't
-        perfectly square), so there are subtly different values for x and y.
-        It is in floating point pixel values e.g. <288.87, 288.36>.
-        '''
-        return self._focal_length
-
-    @property
-    def center(self):
-        ''':class:`cozmo.util.Vector2`: The focal center of the camera.
-
-        This is the position of the optical center of projection within the
-        image. It will be close to the center of the image, but adjusted based
-        on the calibration of the lens at the factory. It is in floating point
-        pixel values e.g. <155.11, 111.40>.
-        '''
-        return self._center
-
-    @property
-    def fov_x(self):
-        ''':class:`cozmo.util.Angle`: The x (horizontal) field of view.'''
-        return self._fov_x
-
-    @property
-    def fov_y(self):
-        ''':class:`cozmo.util.Angle`: The y (vertical) field of view.'''
-        return self._fov_y
-
-    # The fixed range of values supported for this camera.
-
-    @property
-    def min_exposure_time_ms(self):
-        '''int: The minimum supported exposure time in milliseconds.'''
-        return self._min_exposure_time_ms
-
-    @property
-    def max_exposure_time_ms(self):
-        '''int: The maximum supported exposure time in milliseconds.'''
-        return self._max_exposure_time_ms
-
-    @property
-    def min_camera_gain(self):
-        '''float: The minimum supported camera gain.'''
-        return self._min_camera_gain
-
-    @property
-    def max_camera_gain(self):
-        '''float: The maximum supported camera gain.'''
-        return self._max_camera_gain
-
-    # The current camera exposure/gain settings, these update live.
-
-    @property
-    def is_auto_exposure_enabled(self):
-        '''bool: True if auto exposure is currently enabled
-
-        If auto exposure is enabled the `camera_gain` and `exposure_ms`
-        values will constantly be updated by Cozmo.
-        '''
-        return self._auto_exposure_enabled
-
-    @property
-    def camera_gain(self):
-        '''float: The current camera gain setting.'''
-        return self._camera_gain
-
-    @property
-    def exposure_ms(self):
-        '''int: The current camera exposure setting in milliseconds.'''
-        return self._exposure_ms
-
-
 class Robot(event.Dispatcher):
     """The interface to a Cozmo robot.
 
@@ -664,6 +537,8 @@ class Robot(event.Dispatcher):
     #: :class:`cozmo.camera.Camera` class or subclass instance.
     camera_factory = camera.Camera
 
+    #: callable: The factory function that returns a
+    #: :class:`cozmo.robot.PerformOffChargerContext` class or subclass instance.
     perform_off_charger_factory = PerformOffChargerContext
 
     #: callable: The factory function that returns a
@@ -673,7 +548,7 @@ class Robot(event.Dispatcher):
     # other attributes
 
     #: bool: Set to True if the robot should drive off the charger as soon
-    # as the SDK connects to the engine.  Defaults to True.
+    #: as the SDK connects to the engine.  Defaults to True.
     drive_off_charger_on_connect = True  # Required for most movement actions
 
     _is_behavior_running = False
@@ -745,8 +620,6 @@ class Robot(event.Dispatcher):
         self._serial_number_body = 0
         self._model_number = 0
         self._hw_version = 0
-
-        self._camera_config = None  # type: CameraConfig
 
         # send all received events to the world and action dispatcher
         self._add_child_dispatcher(self._action_dispatcher)
@@ -939,8 +812,14 @@ class Robot(event.Dispatcher):
 
     @property
     def camera_config(self):
-        ''':class:`cozmo.robot.CameraConfig`: The read-only config/calibration for this robot's camera'''
-        return self._camera_config
+        ''':class:`cozmo.robot.CameraConfig`: The read-only config/calibration for this robot's camera
+
+        .. deprecated:: 0.12.0
+           Use: :meth:`cozmo.camera.Camera.config` instead.
+        '''
+        warnings.warn("The 'robot.camera_config' method is deprecated, "
+                      "use 'robot.camera.config' instead", DeprecationWarning, stacklevel=2)
+        return self.camera.config
 
     @property
     def serial(self):
@@ -966,16 +845,15 @@ class Robot(event.Dispatcher):
     def _recv_msg_image_chunk(self, evt, *, msg):
         self.camera.dispatch_event(evt)
 
+    def _recv_msg_current_camera_params(self, evt, *, msg):
+        self.camera.dispatch_event(evt)
+
     def _recv_msg_per_robot_settings(self, evt, *, msg):
         self._serial_number_head = msg.serialNumberHead
         self._serial_number_body = msg.serialNumberBody
         self._model_number = msg.modelNumber
         self._hw_version = msg.hwVersion
-        self._camera_config = CameraConfig._create_from_clad(msg.cameraConfig)
-
-    def _recv_msg_current_camera_params(self, evt, *, msg):
-        if self._camera_config is not None:
-            self._camera_config._update_params(msg.cameraGain, msg.exposure_ms, msg.autoExposureEnabled)
+        self.camera._set_config(msg.cameraConfig)
 
     def _recv_msg_robot_state(self, evt, *, msg):
         self._pose = util.Pose(x=msg.pose.x, y=msg.pose.y, z=msg.pose.z,
@@ -1052,50 +930,22 @@ class Robot(event.Dispatcher):
     ### Camera Commands ###
 
     def enable_auto_exposure(self):
-        '''Enable auto exposure on Cozmo's Camera.
-
-        Enable auto exposure on Cozmo's camera to constantly update the exposure
-        time and gain values based on the recent images. This is the default mode
-        when any SDK program starts.
         '''
-        msg = _clad_to_engine_iface.SetCameraSettings(enableAutoExposure=True)
-        self.conn.send_msg(msg)
+        .. deprecated:: 0.12.0
+           Use: :meth:`cozmo.camera.Camera.enable_auto_exposure` instead.
+        '''
+        warnings.warn("The 'robot.enable_auto_exposure' method is deprecated, "
+                      "use 'robot.camera.enable_auto_exposure' instead.", DeprecationWarning, stacklevel=2)
+        self.camera.enable_auto_exposure()
 
     def set_manual_exposure(self, exposure_ms, gain):
-        '''Set manual exposure values for Cozmo's Camera.
-
-        Disable auto exposure on Cozmo's camera and force the specified exposure
-        time and gain values.
-
-        Args:
-            exposure_ms (int): The desired exposure time in milliseconds.
-                Must be within the robot's
-                :attr:`~cozmo.robot.Robot.camera_config` exposure range from
-                :attr:`~cozmo.robot.CameraConfig.min_exposure_time_ms` to
-                :attr:`~cozmo.robot.CameraConfig.max_exposure_time_ms`
-            gain (float): The desired gain value.
-                Must be within the robot's
-                :attr:`~cozmo.robot.Robot.camera_config` gain range from
-                :attr:`~cozmo.robot.CameraConfig.min_camera_gain` to
-                :attr:`~cozmo.robot.CameraConfig.max_camera_gain`
-
-        Raises:
-            :class:`ValueError` if supplied an out-of-range exposure or gain.
         '''
-        cam = self.camera_config
-
-        if (exposure_ms < cam.min_exposure_time_ms) or (exposure_ms > cam.max_exposure_time_ms):
-            raise ValueError('exposure_ms %s out of range %s..%s' %
-                             (exposure_ms, cam.min_exposure_time_ms, cam.max_exposure_time_ms))
-
-        if (gain < cam.min_camera_gain) or (gain > cam.max_camera_gain):
-            raise ValueError('gain %s out of range %s..%s' %
-                             (gain, cam.min_camera_gain, cam.max_camera_gain))
-
-        msg = _clad_to_engine_iface.SetCameraSettings(enableAutoExposure=False,
-                                                      exposure_ms=exposure_ms,
-                                                      gain=gain)
-        self.conn.send_msg(msg)
+        .. deprecated:: 0.12.0
+           Use: :meth:`cozmo.camera.Camera.set_manual_exposure` instead.
+        '''
+        warnings.warn("The 'robot.set_manual_exposure' method is deprecated, "
+                      "use 'robot.camera.set_manual_exposure' instead.", DeprecationWarning, stacklevel=2)
+        self.camera.set_manual_exposure(exposure_ms, gain)
 
     ### Low-Level Commands ###
 

--- a/src/cozmo/run.py
+++ b/src/cozmo/run.py
@@ -50,6 +50,7 @@ import shutil
 import subprocess
 import sys
 import types
+import warnings
 
 from . import logger, logger_protocol
 
@@ -645,7 +646,8 @@ def connect_with_tkviewer(f, conn_factory=conn.CozmoConnection, connector=None, 
 
 
 def setup_basic_logging(general_log_level=None, protocol_log_level=None,
-        protocol_log_messages=clad_protocol.LOG_ALL, target=sys.stderr):
+        protocol_log_messages=clad_protocol.LOG_ALL, target=sys.stderr,
+        deprecated_filter="default"):
     '''Helper to perform basic setup of the Python logging machinery.
 
     The SDK defines two loggers:
@@ -669,7 +671,15 @@ def setup_basic_logging(general_log_level=None, protocol_log_level=None,
             the COMZO_PROTOCOL_LOG_MESSAGES if available which should be
             a comma separated list of message names (case sensitive).
         target (object): The stream to send the log data to; defaults to stderr
+        deprecated_filter (str): The filter for any DeprecationWarning messages.
+            This is defaulted to "default" which shows the warning once per
+            location. You can hide all deprecated warnings by passing in "ignore",
+            see https://docs.python.org/3/library/warnings.html#warning-filter
+            for more information.
     '''
+    if deprecated_filter is not None:
+        warnings.filterwarnings(deprecated_filter, category=DeprecationWarning)
+
     if general_log_level is None:
         general_log_level = os.environ.get('COZMO_LOG_LEVEL', logging.INFO)
     if protocol_log_level is None:
@@ -695,7 +705,8 @@ def setup_basic_logging(general_log_level=None, protocol_log_level=None,
 
 
 def run_program(f, use_viewer=False, conn_factory=conn.CozmoConnection,
-               connector=None, force_viewer_on_top=False):
+                connector=None, force_viewer_on_top=False,
+                deprecated_filter="default"):
     '''Connect to Cozmo and run the provided program/function f.
 
     Args:
@@ -712,8 +723,13 @@ def run_program(f, use_viewer=False, conn_factory=conn.CozmoConnection,
             has the Cozmo app running in SDK mode.
         force_viewer_on_top (bool): Specifies whether the window should be
             forced on top of all others (only relevant if use_viewer is True).
+        deprecated_filter (str): The filter for any DeprecationWarning messages.
+            This is defaulted to "default" which shows the warning once per
+            location. You can hide all deprecated warnings by passing in "ignore",
+            see https://docs.python.org/3/library/warnings.html#warning-filter
+            for more information.
     '''
-    setup_basic_logging()
+    setup_basic_logging(deprecated_filter=deprecated_filter)
 
     # Wrap f (a function that takes in an already created robot)
     # with a function that accepts a cozmo.conn.CozmoConnection


### PR DESCRIPTION
Moved CameraConfig from roboy.py into camera.py
Deprecated robot.camera_config, robot.enable_auto_exposure and robot.set_manual_exposure
Updated 04_exposure example to match, and made it run once in grayscale and once in color.
Fixed a couple of small docstring issues in robot.py whilst getting the camera doc changes to work.