### PR TITLE
COZMO-10293 Make Version Mismatch error stand out more

### DIFF
--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -335,31 +335,52 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
             except AttributeError:
                 pass
 
+            line_seperator = "=" * 80
+            error_message = "\n" + line_seperator + "\n"
+
             if not build_versions_match:
-                logger.warning('Build versions do not match (cozmoclad version %s != app version %s) - connection refused',
-                                cozmoclad.__build_version__, msg.buildVersion)
+
+                def _trimmed_version(ver_string):
+                    # Trim leading zeros from the version string.
+                    trimmed_string = ""
+                    for i in ver_string.split("."):
+                        trimmed_string += str(int(i)) + "."
+                    return trimmed_string[:-1]  # remove trailing "."
+
+                error_message += ("App and SDK versions do not match!\n"
+                                  "----------------------------------\n"
+                                  "SDK's cozmoclad version: %s\n"
+                                  "         != app version: %s\n\n"
+                                  % (cozmoclad.__version__, _trimmed_version(msg.buildVersion)))
 
                 if cozmoclad.__build_version__ < msg.buildVersion:
                     # App is newer
-                    logger.error(
-                        'Please update your SDK to the newest version by calling command: '
-                        '"pip3 install --user --upgrade cozmo" '
-                        'and downloading the latest examples from http://cozmosdk.anki.com/docs/downloads.html')
+                    error_message += ('Please update your SDK to the newest version by calling command:\n'
+                                      '"pip3 install --user --upgrade cozmo"\n'
+                                      'and downloading the latest examples from:\n'
+                                      'http://cozmosdk.anki.com/docs/downloads.html\n')
                 else:
                     # SDK is newer
-                    logger.error("Please update your app to the most recent version on the app store.")
-                    logger.error("Or, if you prefer, please determine which SDK version matches your app version at:")
-                    logger.error("http://go.anki.com/cozmo-sdk-version")
-                    logger.error("Then downgrade your SDK by calling the following command, replacing")
-                    logger.error("SDK_VERSION with the version listed at that page:")
-                    logger.error("'pip3 install --ignore-installed cozmo==SDK_VERSION'")
+                    error_message += ('Please either:\n\n'
+                                      '1) Update your app to the most recent version on the app store.\n'
+                                      '2) Or, if you prefer, please determine which SDK version matches\n'
+                                      '   your app version at: http://go.anki.com/cozmo-sdk-version\n'
+                                      '   Then downgrade your SDK by calling the following command,\n'
+                                      '   replacing SDK_VERSION with the version listed at that page:\n'
+                                      '   "pip3 install --ignore-installed cozmo==SDK_VERSION"\n')
 
             else:
                 # CLAD version mismatch
-                logger.error('Your Python and C++ CLAD versions do not match - connection refused.')
-                logger.error('Please check that you have the most recent versions of both the SDK and the Cozmo app.')
-                logger.error("You may update your SDK by calling: 'pip3 install --user --ignore-installed cozmo'.")
-                logger.error("Please also check the app store for a Cozmo app update.")
+                error_message += ('CLAD Hashes do not match!\n'
+                                  '-------------------------\n'
+                                  'Your Python and C++ CLAD versions do not match - connection refused.\n'
+                                  'Please check that you have the most recent versions of both the SDK and the\n'
+                                  'Cozmo app. You may update your SDK by calling:\n'
+                                  '"pip3 install --user --ignore-installed cozmo".\n'
+                                  'Please also check the app store for a Cozmo app update.\n')
+
+            error_message += line_seperator
+            logger.error(error_message)
 
             exc = exceptions.SDKVersionMismatch("SDK library does not match software running on device")
             self.abort(exc)

--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -335,8 +335,8 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
             except AttributeError:
                 pass
 
-            line_seperator = "=" * 80
-            error_message = "\n" + line_seperator + "\n"
+            line_separator = "=" * 80
+            error_message = "\n" + line_separator + "\n"
 
             if not build_versions_match:
 
@@ -379,7 +379,7 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
                                   '"pip3 install --user --ignore-installed cozmo".\n'
                                   'Please also check the app store for a Cozmo app update.\n')
 
-            error_message += line_seperator
+            error_message += line_separator
             logger.error(error_message)
 
             exc = exceptions.SDKVersionMismatch("SDK library does not match software running on device")


### PR DESCRIPTION
Make the version mismatch error stand-out from the rest of the Python text by adding more spacing, new lines to separate it from the long prepended text on each log message, and generally improving the formatting.