### PR TITLE
COZMO-10390 PerformOffCharger drive-off action done in_parallel

### DIFF
--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -434,7 +434,7 @@ class PerformOffChargerContext(event.Dispatcher):
     async def __aenter__(self):
         self.was_on_charger = self.robot.is_on_charger
         if self.was_on_charger:
-            await self.robot.drive_off_charger_contacts().wait_for_completed()
+            await self.robot.drive_off_charger_contacts(in_parallel=True).wait_for_completed()
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):
@@ -852,7 +852,7 @@ class Robot(event.Dispatcher):
 
     @property
     def is_pathing(self):
-        '''bool: True fi Cozmo currently traversing a path.'''
+        '''bool: True if Cozmo currently traversing a path.'''
         return (self._robot_status_flags & _clad_to_game_cozmo.RobotStatusFlag.IS_PATHING) != 0
 
     @property
@@ -872,7 +872,7 @@ class Robot(event.Dispatcher):
 
     @property
     def is_on_charger(self):
-        '''bool: True fi Cozmo currently on the charger.'''
+        '''bool: True if Cozmo currently on the charger.'''
         return (self._robot_status_flags & _clad_to_game_cozmo.RobotStatusFlag.IS_ON_CHARGER) != 0
 
     @property


### PR DESCRIPTION
Driving off with in_paralelel=True means that it’s now possible to have an existing action (e.g a face action) in progress whilst Cozmo drives off the charger (previously this would force you to first abort any pending actions).
Fixed on charger docstring fi vs if typo, and other instance next to it.