### PR TITLE
COZMO-8803 Replace name_face Action with Behavior

### DIFF
--- a/src/cozmo/behavior.py
+++ b/src/cozmo/behavior.py
@@ -56,7 +56,7 @@ BEHAVIOR_REQUESTED = 'behavior_requested'
 #: string: Behavior running state
 BEHAVIOR_RUNNING = 'behavior_running'
 
-#: string: Behavior succeeded state
+#: string: Behavior stopped state
 BEHAVIOR_STOPPED = 'behavior_stopped'
 
 
@@ -100,7 +100,7 @@ class Behavior(event.Dispatcher):
         if self._state != BEHAVIOR_REQUESTED:
             # has not been requested (is an unrelated behavior transition)
             if self.is_running:
-                logger.warning("Behavior '%s' reported started when already running!?")
+                logger.warning("Behavior '%s' unexpectedly reported started when already running")
             return
         self._state = BEHAVIOR_RUNNING
         self.dispatch_event(EvtBehaviorStarted, behavior=self, behavior_type_name=self.type.name)

--- a/src/cozmo/behavior.py
+++ b/src/cozmo/behavior.py
@@ -33,7 +33,9 @@ behaviors.
 '''
 
 # __all__ should order by constants, event classes, other classes, functions.
-__all__ = ['EvtBehaviorStarted', 'EvtBehaviorStopped',
+__all__ = ['BEHAVIOR_IDLE', 'BEHAVIOR_REQUESTED', 'BEHAVIOR_RUNNING',
+           'BEHAVIOR_STOPPED',
+           'EvtBehaviorRequested', 'EvtBehaviorStarted', 'EvtBehaviorStopped',
            'Behavior', 'BehaviorTypes']
 
 import asyncio
@@ -45,8 +47,27 @@ from . import event
 from ._clad import _clad_to_engine_iface, _clad_to_engine_cozmo
 
 
+#: string: Behavior idle state (not requested to run)
+BEHAVIOR_IDLE = 'behavior_idle'
+
+#: string: Behavior requested state (waiting for engine to start it)
+BEHAVIOR_REQUESTED = 'behavior_requested'
+
+#: string: Behavior running state
+BEHAVIOR_RUNNING = 'behavior_running'
+
+#: string: Behavior succeeded state
+BEHAVIOR_STOPPED = 'behavior_stopped'
+
+
+class EvtBehaviorRequested(event.Event):
+    '''Triggered when a behavior is requested to start.'''
+    behavior = 'The Behavior object'
+    behavior_type_name = 'The behavior type name - equivalent to behavior.type.name'
+
+
 class EvtBehaviorStarted(event.Event):
-    '''Triggered when a behavior starts.'''
+    '''Triggered when a behavior starts running on the robot.'''
     behavior = 'The Behavior object'
     behavior_type_name = 'The behavior type name - equivalent to behavior.type.name'
 
@@ -55,7 +76,6 @@ class EvtBehaviorStopped(event.Event):
     '''Triggered when a behavior stops.'''
     behavior = 'The behavior type object'
     behavior_type_name = 'The behavior type name - equivalent to behavior.type.name'
-
 
 
 class Behavior(event.Dispatcher):
@@ -68,29 +88,85 @@ class Behavior(event.Dispatcher):
         super().__init__(**kw)
         self.robot = robot
         self.type = behavior_type
-        self._is_active = is_active
+        self._state = BEHAVIOR_IDLE
         if is_active:
-            self.dispatch_event(EvtBehaviorStarted, behavior=self, behavior_type_name=self.type.name)
+            self._state = BEHAVIOR_REQUESTED
+            self.dispatch_event(EvtBehaviorRequested, behavior=self, behavior_type_name=self.type.name)
 
     def __repr__(self):
         return '<%s type="%s">' % (self.__class__.__name__, self.type.name)
+
+    def _on_engine_started(self):
+        if self._state != BEHAVIOR_REQUESTED:
+            # has not been requested (is an unrelated behavior transition)
+            if self.is_running:
+                logger.warning("Behavior '%s' reported started when already running!?")
+            return
+        self._state = BEHAVIOR_RUNNING
+        self.dispatch_event(EvtBehaviorStarted, behavior=self, behavior_type_name=self.type.name)
+
+    def _set_stopped(self):
+        if not self.is_active:
+            return
+        self._state = BEHAVIOR_STOPPED
+        self.dispatch_event(EvtBehaviorStopped, behavior=self, behavior_type_name=self.type.name)
 
     def stop(self):
         '''Requests that the robot stop performing the behavior.
 
         Has no effect if the behavior is not presently active.
         '''
-        if not self._is_active:
+        if not self.is_active:
             return
-        self.robot._stop_behavior()
-        self._is_active = False
-        self.dispatch_event(EvtBehaviorStopped, behavior=self, behavior_type_name=self.type.name)
+        self.robot._set_none_behavior()
+        self._set_stopped()
 
     @property
     def is_active(self):
-        '''bool: True if the behavior is currently active on the robot.'''
-        return self._is_active
+        '''bool: True if the behavior is currently active and may run on the robot.'''
+        return self._state == BEHAVIOR_REQUESTED or self._state == BEHAVIOR_RUNNING
 
+    @property
+    def is_running(self):
+        '''bool: True if the behavior is currently running on the robot.'''
+        return self._state == BEHAVIOR_RUNNING
+
+    @property
+    def is_completed(self):
+        return self._state == BEHAVIOR_STOPPED
+
+    async def wait_for_started(self, timeout=5):
+        '''Waits for the behavior to start.
+
+        Args:
+            timeout (int or None): Maximum time in seconds to wait for the event.
+                Pass None to wait indefinitely. If a behavior can run it should
+                usually start within ~0.2 seconds.
+        Raises:
+            :class:`asyncio.TimeoutError`
+        '''
+        if self.is_running:
+            # Already started running
+            return
+        await self.wait_for(EvtBehaviorStarted, timeout=timeout)
+
+    async def wait_for_completed(self, timeout=None):
+        '''Waits for the behavior to complete.
+
+        Args:
+            timeout (int or None): Maximum time in seconds to wait for the event.
+                Pass None to wait indefinitely.
+        Raises:
+            :class:`asyncio.TimeoutError`
+        '''
+        if self.is_completed:
+            # Already complete
+            return
+        # Wait for behavior to start first - it can't complete without starting,
+        # and if it doesn't start within a fraction of a second it probably
+        # never will
+        await self.wait_for_started()
+        await self.wait_for(EvtBehaviorStopped, timeout=timeout)
 
 
 _BehaviorType = collections.namedtuple('_BehaviorType', ['name', 'id'])
@@ -121,6 +197,20 @@ try:
 
         #: Pickup one block, and stack it onto another block.
         StackBlocks = _BehaviorType("StackBlocks", _clad_to_engine_cozmo.ExecutableBehaviorType.StackBlocks)
+
+        # Enroll a Face - for internal use by Face.name_face (requires additional pre/post setup)
+        _EnrollFace = _BehaviorType("EnrollFace", _clad_to_engine_cozmo.ExecutableBehaviorType.EnrollFace)
+
+        _id_to_behavior_type = dict()
+
+        @classmethod
+        def find_by_id(cls, id):
+            return cls._id_to_behavior_type.get(id)
+
+    # populate BehaviorTypes _id_to_behavior_type mapping
+    for (_name, _bt) in BehaviorTypes.__dict__.items():
+        if isinstance(_bt, _BehaviorType):
+            BehaviorTypes._id_to_behavior_type[_bt.id] = _bt
 
 except AttributeError as exc:
     err = ('Incorrect version of cozmoclad package installed.  '

--- a/src/cozmo/behavior.py
+++ b/src/cozmo/behavior.py
@@ -145,7 +145,7 @@ class Behavior(event.Dispatcher):
         Raises:
             :class:`asyncio.TimeoutError`
         '''
-        if self.is_running:
+        if self.is_running or self.is_completed:
             # Already started running
             return
         await self.wait_for(EvtBehaviorStarted, timeout=timeout)

--- a/src/cozmo/faces.py
+++ b/src/cozmo/faces.py
@@ -40,17 +40,15 @@ __all__ = ['FACE_VISIBILITY_TIMEOUT',
            'update_enrolled_face_by_id']
 
 
-import math
-import time
 
 from . import logger
 
-from . import action
+from . import behavior
 from . import event
 from . import objects
 from . import util
 
-from ._clad import _clad_to_engine_iface, _clad_to_engine_cozmo
+from ._clad import _clad_to_engine_iface
 from ._clad import _clad_to_game_anki
 
 
@@ -359,21 +357,30 @@ class Face(objects.ObservableElement):
 
     #### Commands ####
 
-    # TODO: There is no longer an action for naming the face - replace this method
-    #       With usage of the new Behavior for naming the face.
-    # def name_face(self, name):
-    #     '''Assign a name to this face. Cozmo will remember this name between SDK runs.
-    #
-    #     Args:
-    #         name (string): The name that will be assigned to this face
-    #     Returns:
-    #         An instance of :class:`cozmo.faces.EnrollNamedFace` action object
-    #     '''
-    #     logger.info("Sending enroll named face request for face=%s and name=%s", self, name)
-    #     action = self.enroll_named_face_factory(face=self, name=name, conn=self.conn,
-    #                                             robot=self._robot, dispatch_parent=self)
-    #     self._robot._action_dispatcher._send_single_action(action)
-    #     return action
+    def name_face(self, name):
+        '''Assign a name to this face. Cozmo will remember this name between SDK runs.
+
+        Args:
+            name (string): The name that will be assigned to this face
+        Returns:
+            An instance of :class:`cozmo.behavior.Behavior` object
+        '''
+        if not name:
+            raise ValueError("Invalid string passed to name_face")
+
+        logger.info("Enrolling face=%s with name='%s'", self, name)
+
+        # Note: saveID must be 0 if face_id doesn't already have a name
+        msg = _clad_to_engine_iface.SetFaceToEnroll(name=name,
+                                                    observedID=self.face_id,
+                                                    saveID=0,
+                                                    saveToRobot=True,
+                                                    sayName=False,
+                                                    useMusic=False)
+        self.conn.send_msg(msg)
+
+        enroll_behavior = self._robot.start_behavior(behavior.BehaviorTypes._EnrollFace)
+        return enroll_behavior
 
     def rename_face(self, new_name):
         '''Change the name assigned to the face. Cozmo will remember this name between SDK runs.

--- a/src/cozmo/faces.py
+++ b/src/cozmo/faces.py
@@ -357,16 +357,30 @@ class Face(objects.ObservableElement):
 
     #### Commands ####
 
+    def _is_valid_name(self, name):
+        if not (name and name.isalpha()):
+            return False
+        try:
+            name.encode('ascii')
+        except UnicodeEncodeError:
+            return False
+
+        return True
+
     def name_face(self, name):
         '''Assign a name to this face. Cozmo will remember this name between SDK runs.
 
         Args:
-            name (string): The name that will be assigned to this face
+            name (string): The name that will be assigned to this face. Must
+                be a non-empty ASCII string of alphabetic characters only.
         Returns:
             An instance of :class:`cozmo.behavior.Behavior` object
+        Raises:
+            :class:`ValueError` if name is invalid.
         '''
-        if not name:
-            raise ValueError("Invalid string passed to name_face")
+        if not self._is_valid_name(name):
+            raise ValueError("new_name '%s' is an invalid face name. "
+                             "Must be non-empty and contain only alphabetic ASCII characters." % name)
 
         logger.info("Enrolling face=%s with name='%s'", self, name)
 
@@ -386,8 +400,14 @@ class Face(objects.ObservableElement):
         '''Change the name assigned to the face. Cozmo will remember this name between SDK runs.
 
         Args:
-            new_name (string): The new name for the face
+            new_name (string): The new name that will be assigned to this face. Must
+                be a non-empty ASCII string of alphabetic characters only.
+        Raises:
+            :class:`ValueError` if new_name is invalid.
         '''
+        if not self._is_valid_name(new_name):
+            raise ValueError("new_name '%s' is an invalid face name. "
+                             "Must be non-empty and contain only alphabetic ASCII characters." % new_name)
         update_enrolled_face_by_id(self.conn, self.face_id, self.name, new_name)
 
     def erase_enrolled_face(self):

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -551,7 +551,7 @@ class Robot(event.Dispatcher):
     #: as the SDK connects to the engine.  Defaults to True.
     drive_off_charger_on_connect = True  # Required for most movement actions
 
-    _is_behavior_running = False
+    _current_behavior = None  # type: Behavior
     _is_freeplay_mode_active = False
 
     def __init__(self, conn, robot_id, is_primary, **kw):
@@ -635,7 +635,7 @@ class Robot(event.Dispatcher):
             # Note: Robot state is reset on entering SDK mode, and after any SDK program exits
             self.stop_all_motors()
             self.enable_all_reaction_triggers(False)
-            self._stop_behavior()
+            self._set_none_behavior()
 
             # Ensure the SDK has full control of cube lights
             self._set_cube_light_state(False)
@@ -653,12 +653,13 @@ class Robot(event.Dispatcher):
             self.dispatch_event(EvtRobotReady, robot=self)
         asyncio.ensure_future(_init(), loop=self._loop)
 
-    def _stop_behavior(self):
+    def _set_none_behavior(self):
         # Internal helper method called from Behavior.stop etc.
         msg = _clad_to_engine_iface.ExecuteBehaviorByExecutableType(
                 behaviorType=_clad_to_engine_cozmo.ExecutableBehaviorType.NoneBehavior)
         self.conn.send_msg(msg)
-        self._is_behavior_running = False
+        if self._current_behavior is not None:
+            self._current_behavior._set_stopped()
 
     def _set_cube_light_state(self, enable):
         msg = _clad_to_engine_iface.EnableLightStates(enable=enable, objectID=-1)
@@ -784,6 +785,14 @@ class Robot(event.Dispatcher):
         return self._head_angle
 
     @property
+    def current_behavior(self):
+        ''':class:`cozmo.behavior.Behavior`: Cozmo's currently active behavior.'''
+        if self._current_behavior is not None and self._current_behavior.is_active:
+            return self._current_behavior
+        else:
+            return None
+
+    @property
     def is_behavior_running(self):
         '''bool: True if Cozmo is currently running a behavior.
 
@@ -792,7 +801,8 @@ class Robot(event.Dispatcher):
         Cozmo whilst in this mode will likely have unexpected behavior on
         the robot and confuse Cozmo.
         '''
-        return self._is_behavior_running
+        return (self.is_freeplay_mode_active or
+                (self._current_behavior is not None and self._current_behavior.is_active))
 
     @property
     def is_freeplay_mode_active(self):
@@ -879,6 +889,14 @@ class Robot(event.Dispatcher):
 
         if msg.robotID != self.robot_id:
             logger.error("robot ID changed mismatch (msg=%s, self=%s)", msg.robotID, self.robot_id )
+
+    def _recv_msg_behavior_transition(self, evt, *, msg):
+        new_type = behavior.BehaviorTypes.find_by_id(msg.newBehaviorExecType)
+        if self._current_behavior is not None:
+            if new_type == self._current_behavior.type:
+                self._current_behavior._on_engine_started()
+            else:
+                self._current_behavior._set_stopped()
 
     #### Public Event Handlers ####
 
@@ -1314,14 +1332,18 @@ class Robot(event.Dispatcher):
         '''
         if not isinstance(behavior_type, behavior._BehaviorType):
             raise TypeError('Invalid behavior supplied')
+
+        if self._current_behavior is not None:
+            self._current_behavior._set_stopped()
+
         b = self.behavior_factory(self, behavior_type, is_active=True, dispatch_parent=self)
         msg = _clad_to_engine_iface.ExecuteBehaviorByExecutableType(
                 behaviorType=behavior_type.id)
         self.conn.send_msg(msg)
-        self._is_behavior_running = True
+        self._current_behavior = b
         return b
 
-    async def run_timed_behavior(self, behavior_type, active_time):
+    async def run_timed_behavior(self, behavior_type, max_active_time):
         '''Executes a behavior for a set number of seconds.
 
         This call blocks and stops the behavior after active_time seconds.
@@ -1329,13 +1351,16 @@ class Robot(event.Dispatcher):
         Args:
             behavior_type (:class:`cozmo.behavior._BehaviorType): An attribute of
                 :class:`cozmo.behavior.BehaviorTypes`.
-            active_time (float): specifies the time to execute in seconds
+            max_active_time (float): specifies the maximum time to execute in seconds
         Raises:
             :class:`TypeError` if an invalid behavior type is supplied.
         '''
         b = self.start_behavior(behavior_type)
-        await asyncio.sleep(active_time, loop=self._loop)
-        b.stop()
+        try:
+            await b.wait_for_completed(timeout=max_active_time)
+        except asyncio.TimeoutError:
+            # It didn't complete within the time, stop it
+            b.stop()
 
     def start_freeplay_behaviors(self):
         '''Start running freeplay behaviors on Cozmo
@@ -1365,7 +1390,7 @@ class Robot(event.Dispatcher):
         self.conn.send_msg(msg)
 
         self._is_freeplay_mode_active = False
-        self._stop_behavior()
+        self._set_none_behavior()
         self.abort_all_actions()
 
     ## Object Commands ##

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -1343,7 +1343,7 @@ class Robot(event.Dispatcher):
         self._current_behavior = b
         return b
 
-    async def run_timed_behavior(self, behavior_type, max_active_time):
+    async def run_timed_behavior(self, behavior_type, active_time):
         '''Executes a behavior for a set number of seconds.
 
         This call blocks and stops the behavior after active_time seconds.
@@ -1351,13 +1351,13 @@ class Robot(event.Dispatcher):
         Args:
             behavior_type (:class:`cozmo.behavior._BehaviorType): An attribute of
                 :class:`cozmo.behavior.BehaviorTypes`.
-            max_active_time (float): specifies the maximum time to execute in seconds
+            active_time (float): specifies the maximum time to execute in seconds
         Raises:
             :class:`TypeError` if an invalid behavior type is supplied.
         '''
         b = self.start_behavior(behavior_type)
         try:
-            await b.wait_for_completed(timeout=max_active_time)
+            await b.wait_for_completed(timeout=active_time)
         except asyncio.TimeoutError:
             # It didn't complete within the time, stop it
             b.stop()

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -1336,12 +1336,13 @@ class Robot(event.Dispatcher):
         if self._current_behavior is not None:
             self._current_behavior._set_stopped()
 
-        b = self.behavior_factory(self, behavior_type, is_active=True, dispatch_parent=self)
+        new_behavior = self.behavior_factory(self, behavior_type,
+                                             is_active=True, dispatch_parent=self)
         msg = _clad_to_engine_iface.ExecuteBehaviorByExecutableType(
                 behaviorType=behavior_type.id)
         self.conn.send_msg(msg)
-        self._current_behavior = b
-        return b
+        self._current_behavior = new_behavior
+        return new_behavior
 
     async def run_timed_behavior(self, behavior_type, active_time):
         '''Executes a behavior for a set number of seconds.


### PR DESCRIPTION
Face.name_face was removed in a recent update as the Action to perform this internally was removed. This has been replaced with a Behavior, so the method has been revived to use that.
To enable the use of a Behavior in a way closer to an Action, the behavior code has been updated to track changes in behavior to allow to wait for a behavior to complete, and also catch when a behavior never starts (e.g. if it is not considered runnable if various engine preconditions are not met).