### PR TITLE
COZMO-10798 Fix warnings in docs and code

### DIFF
--- a/src/cozmo/faces.py
+++ b/src/cozmo/faces.py
@@ -278,12 +278,12 @@ class Face(objects.ObservableElement):
     def expression(self):
         '''string: The facial expression Cozmo has recognized on the face.
 
-        Will be ``FACIAL_EXPRESSION_UNKNOWN`` by default if you haven't called
+        Will be :attr:`FACIAL_EXPRESSION_UNKNOWN` by default if you haven't called
         :meth:`cozmo.robot.Robot.enable_facial_expression_estimation` to enable
         the facial expression estimation. Otherwise it will be equal to one of:
-        ``FACIAL_EXPRESSION_NEUTRAL``, ``FACIAL_EXPRESSION_HAPPY``,
-        ``FACIAL_EXPRESSION_SURPRISED``, ``FACIAL_EXPRESSION_ANGRY``,
-        or ``FACIAL_EXPRESSION_SAD``.
+        :attr:`FACIAL_EXPRESSION_NEUTRAL`, :attr:`FACIAL_EXPRESSION_HAPPY`,
+        :attr:`FACIAL_EXPRESSION_SURPRISED`, :attr:`FACIAL_EXPRESSION_ANGRY`,
+        or :attr:`FACIAL_EXPRESSION_SAD`.
         '''
         return self._expression
 

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -38,7 +38,7 @@ online documentation.  They will be detected as :class:`CustomObject` instances.
 
 # __all__ should order by constants, event classes, other classes, functions.
 __all__ = ['LightCube1Id', 'LightCube2Id', 'LightCube3Id', 'OBJECT_VISIBILITY_TIMEOUT',
-           'EvtObjectAppeared', 'EvtObjectAvailable',
+           'EvtObjectAppeared',
            'EvtObjectConnectChanged', 'EvtObjectConnected',
            'EvtObjectDisappeared', 'EvtObjectLocated',
            'EvtObjectMoving', 'EvtObjectMovingStarted', 'EvtObjectMovingStopped',
@@ -335,8 +335,8 @@ class ObservableObject(ObservableElement):
         # as a response to a RequestLocatedObjectStates message
         if (self.last_observed_robot_timestamp and
             (self.last_observed_robot_timestamp > object_state.lastObservedTimestamp)):
-            logger.warn("Ignoring old located object_state=%s obj=%s (last_observed_robot_timestamp=%s)",
-                         object_state, self, self.last_observed_robot_timestamp)
+            logger.warning("Ignoring old located object_state=%s obj=%s (last_observed_robot_timestamp=%s)",
+                           object_state, self, self.last_observed_robot_timestamp)
             return
 
         changed_fields = {'last_observed_robot_timestamp', 'pose'}
@@ -622,6 +622,13 @@ class CustomObject(ObservableObject):
 
     See parent class :class:`ObservableObject` for additional properties
     and methods.
+    
+    These objects are created automatically by the engine when Cozmo observes
+    an object with custom markers. For Cozmo to see one of these you must first
+    define an object with custom markers, via one of the following methods:
+    :meth:`~cozmo.world.World.define_custom_box`.
+    :meth:`~cozmo.world.World.define_custom_cube`, or
+    :meth:`~cozmo.world.World.define_custom_wall`
     '''
 
     def __init__(self, conn, world, object_type,
@@ -833,6 +840,8 @@ class FixedCustomObject():
     The position is static in Cozmo's world view; once instantiated, these
     objects never move. This could be used to make Cozmo aware of objects and
     know to plot a path around them even when they don't have any markers.
+    
+    To create these use :meth:`~cozmo.world.World.create_custom_fixed_object`
     '''
 
     is_visible = False

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -365,13 +365,13 @@ class SetLiftHeight(action.Action):
         else:
             self.lift_height_mm = MIN_LIFT_HEIGHT_MM + (height * (MAX_LIFT_HEIGHT_MM - MIN_LIFT_HEIGHT_MM))
 
-        #: float: Maximum speed of Cozmo's head in radians per second
+        #: float: Maximum speed of Cozmo's lift in radians per second
         self.max_speed = max_speed
 
-        #: float: Acceleration of Cozmo's head in radians per second squared
+        #: float: Acceleration of Cozmo's lift in radians per second squared
         self.accel = accel
 
-        #: float: Time for Cozmo's head to turn in seconds
+        #: float: Time for Cozmo's lift to turn in seconds
         self.duration = duration
 
     def _repr_values(self):

--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -117,7 +117,7 @@ class World(event.Dispatcher):
         self.custom_objects = {}
 
         #: :class:`CameraImage`: The latest image received, or None.
-        self.latest_image = None
+        self.latest_image = None  # type: CameraImage
 
         self.light_cubes = {}
 
@@ -371,15 +371,15 @@ class World(event.Dispatcher):
             if obj:
                 obj._handle_located_object_state(object_state)
             updated_objects.add(object_state.objectID)
-        # verify that all objects not received have invalidated poses
+        # ensure that all objects not received have invalidated poses
         for id, obj in self._objects.items():
             if (id not in updated_objects) and obj.pose.is_valid:
-                logger.warn("Object %s still has a valid pose but wasn't part of located_object_state", obj)
+                obj.pose.invalidate()
 
     def _recv_msg_robot_deleted_located_object(self, evt, *, msg):
         obj = self._objects.get(msg.objectID)
         if obj is None:
-            logger.warn("Ignoring deleted_located_object for unknown object ID %s", msg.objectID)
+            logger.warning("Ignoring deleted_located_object for unknown object ID %s", msg.objectID)
         else:
             logger.info("Invalidating pose for deleted located object %s" % obj)
             obj.pose.invalidate()
@@ -835,7 +835,7 @@ class World(event.Dispatcher):
                                       the origin_id of Cozmo.
 
         Returns:
-            A :class:`cozmo.object.FixedCustomObject` instance with the specified dimensions and pose.
+            A :class:`cozmo.objects.FixedCustomObject` instance with the specified dimensions and pose.
         '''
         # Override the origin of the pose to be the same as the robot's. This will make sure they are in
         # the same space in the engine every time.


### PR DESCRIPTION
Removed EvtObjectAvailable reference (it no longer exists)
Replaced logger.warn with logger.warning
Added more detail to CustomObject and FixedCustomObject docstrings to show how to create/use them.
Fixed head vs lift typos in SetLiftHeight
Add type info for World.latest_image (helps Pycharm etc.)
Replaced warning in recv_msg_located_object_states with code to handle that case, as it happens frequently.