### PR TITLE
COZMO-10809 Cube connection and color example

### DIFF
--- a/examples/tutorials/01_basics/09_cube_lights.py
+++ b/examples/tutorials/01_basics/09_cube_lights.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2016 Anki, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the file LICENSE.txt or at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''Control Cozmo's Cube lights
+
+This script shows how you can control Cozmo's cube lights and set
+them to different colors - to red, green and blue in this case.
+'''
+
+import time
+
+import cozmo
+from cozmo.objects import LightCube1Id, LightCube2Id, LightCube3Id
+
+
+def cozmo_program(robot: cozmo.robot.Robot):
+    cube1 = robot.world.get_light_cube(LightCube1Id)  # looks like a paperclip
+    cube2 = robot.world.get_light_cube(LightCube2Id)  # looks like a lamp / heart
+    cube3 = robot.world.get_light_cube(LightCube3Id)  # looks like the letters 'ab' over 'T'
+
+    if cube1 is not None:
+        cube1.set_lights(cozmo.lights.red_light)
+    else:
+        cozmo.logger.warning("Cozmo is not connected to a LightCube1Id cube - check the battery.")
+
+    if cube2 is not None:
+        cube2.set_lights(cozmo.lights.green_light)
+    else:
+        cozmo.logger.warning("Cozmo is not connected to a LightCube2Id cube - check the battery.")
+
+    if cube3 is not None:
+        cube3.set_lights(cozmo.lights.blue_light)
+    else:
+        cozmo.logger.warning("Cozmo is not connected to a LightCube3Id cube - check the battery.")
+
+    # Keep the lights on for 10 seconds until the program exits
+    time.sleep(10)
+
+
+cozmo.run_program(cozmo_program)

--- a/examples/tutorials/01_basics/09_cube_lights.py
+++ b/examples/tutorials/01_basics/09_cube_lights.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2016 Anki, Inc.
+# Copyright (c) 2017 Anki, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -288,6 +288,29 @@ class World(event.Dispatcher):
         '''
         return self._visible_pet_count
 
+    def get_light_cube(self, cube_id):
+        """Returns the light cube with the given cube ID
+                
+        Args:
+            cube_id (int): The light cube ID - should be one of
+                :attr:`~cozmo.objects.LightCube1Id`,
+                :attr:`~cozmo.objects.LightCube2Id` and
+                :attr:`~cozmo.objects.LightCube3Id`. Note: the cube_id is not
+                the same thing as the object_id.
+        Returns:
+            :class:`cozmo.objects.LightCube`: The LightCube object with that cube_id
+        
+        Raises:
+            :class:`ValueError` if the cube_id is invalid.
+        """
+        if cube_id not in {objects.LightCube1Id, objects.LightCube2Id, objects.LightCube3Id}:
+            raise ValueError("Invalid cube_id %s" % cube_id)
+        cube = self.light_cubes.get(cube_id)
+        # Only return the cube if it has an object_id
+        if cube.object_id is not None:
+            return cube
+        return None
+
     #### Private Event Handlers ####
 
     def _recv_msg_robot_observed_object(self, evt, *, msg):
@@ -349,6 +372,9 @@ class World(event.Dispatcher):
         self._dispatch_object_event(evt, msg)
 
     def _recv_msg_object_power_level(self, evt, *, msg):
+        self._dispatch_object_event(evt, msg)
+
+    def _recv_msg_object_connection_state(self, evt, *, msg):
         self._dispatch_object_event(evt, msg)
 
     def _recv_msg_connected_object_states(self, evt, *, msg):


### PR DESCRIPTION
Removed spurious info from EvtObjectConnected
Keep track of LightCube.is_connected
Expanded docstring for “lamp” cube as some people think it looks like a heart.
Moved _recv_msg_object_connection_state to the correct class, and made sure the message gets to the cube
Added World.get_light_cube to make it cleaner to get a cube by ID and automatically handle the case where there was a part-initialized cube (no cube is connected to the robot).
Added cube_lights example that sets cubes to red, green, blue without having to have been seen.