### PR TITLE
COZMO-11024: Align actions not succeeding as often as expected

### DIFF
--- a/src/cozmo/action.py
+++ b/src/cozmo/action.py
@@ -239,9 +239,6 @@ class ActionResults:
     PLACEMENT_GOAL_NOT_FREE = _ActionResult("PLACEMENT_GOAL_NOT_FREE",
                                             _clad_to_game_cozmo.ActionResult.PLACEMENT_GOAL_NOT_FREE)
 
-    #: A retriable action failed more times than the ``num_retries`` limit passed in.
-    REACHED_MAX_NUM_RETRIES = _ActionResult("REACHED_MAX_NUM_RETRIES", _clad_to_game_cozmo.ActionResult.REACHED_MAX_NUM_RETRIES)
-
     #: Cozmo failed to drive off the charger.
     STILL_ON_CHARGER = _ActionResult("STILL_ON_CHARGER", _clad_to_game_cozmo.ActionResult.STILL_ON_CHARGER)
 


### PR DESCRIPTION
This change is to support the removal of an ActionResult which was done in https://github.com/anki/cozmo-one/pull/4136 to improve action retry behavior.