### PR TITLE
COZMO-11731 Actions handling OffTreadsState on their own

### DIFF
--- a/src/cozmo/action.py
+++ b/src/cozmo/action.py
@@ -110,6 +110,9 @@ class ActionResults:
     #: There was an error related to vision markers.
     BAD_MARKER = _ActionResult("BAD_MARKER", _clad_to_game_cozmo.ActionResult.BAD_MARKER)
 
+    # (Undocumented) There was a problem related to a subscribed or unsupported message tag (indicates bug in engine)
+    BAD_MESSAGE_TAG = _ActionResult("BAD_MESSAGE_TAG", _clad_to_game_cozmo.ActionResult.BAD_MESSAGE_TAG)
+
     #: There was a problem with the Object ID provided (e.g. there is no Object with that ID).
     BAD_OBJECT = _ActionResult("BAD_OBJECT", _clad_to_game_cozmo.ActionResult.BAD_OBJECT)
 

--- a/src/cozmo/action.py
+++ b/src/cozmo/action.py
@@ -133,6 +133,11 @@ class ActionResults:
     #: The action was interrupted by another Action or Behavior.
     INTERRUPTED = _ActionResult("INTERRUPTED", _clad_to_game_cozmo.ActionResult.INTERRUPTED)
 
+    #: The robot ended up in an "off treads state" not valid for this action (e.g.
+    #: the robot was placed on its back while executing a turn)
+    INVALID_OFF_TREADS_STATE = _ActionResult("INVALID_OFF_TREADS_STATE",
+                                             _clad_to_game_cozmo.ActionResult.INVALID_OFF_TREADS_STATE)
+
     #: The Up Axis of a carried object doesn't match the desired placement pose.
     MISMATCHED_UP_AXIS = _ActionResult("MISMATCHED_UP_AXIS", _clad_to_game_cozmo.ActionResult.MISMATCHED_UP_AXIS)
 

--- a/src/cozmo/action.py
+++ b/src/cozmo/action.py
@@ -239,9 +239,6 @@ class ActionResults:
     PLACEMENT_GOAL_NOT_FREE = _ActionResult("PLACEMENT_GOAL_NOT_FREE",
                                             _clad_to_game_cozmo.ActionResult.PLACEMENT_GOAL_NOT_FREE)
 
-    #: A retriable action failed more times than the ``num_retries`` limit passed in.
-    REACHED_MAX_NUM_RETRIES = _ActionResult("REACHED_MAX_NUM_RETRIES", _clad_to_game_cozmo.ActionResult.REACHED_MAX_NUM_RETRIES)
-
     #: Cozmo failed to drive off the charger.
     STILL_ON_CHARGER = _ActionResult("STILL_ON_CHARGER", _clad_to_game_cozmo.ActionResult.STILL_ON_CHARGER)
 


### PR DESCRIPTION
Added new Action Result “INVALID_OFF_TREADS_STATE” for situations where the robot ends up in an invalid orientation while executing an action.