### PR TITLE
Fix typo in documentation for Robot constructor

### DIFF
--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -556,7 +556,7 @@ class Robot(event.Dispatcher):
 
     def __init__(self, conn, robot_id, is_primary, **kw):
         super().__init__(**kw)
-        #: :class:`cozmo.conn.CozmoConnectoin`: The active connection to the engine.
+        #: :class:`cozmo.conn.CozmoConnection`: The active connection to the engine.
         self.conn = conn
         #: int: The internal ID number of the robot.
         self.robot_id = robot_id


### PR DESCRIPTION
There was a typo in class cozmo.conn.CozmoConnectoin (should end "ion" not "oin") that meant you couldn't follow that particular link in the online documentation.