### PR TITLE
COZMO-12298 clean up sdk for lint

### DIFF
--- a/src/cozmo/event.py
+++ b/src/cozmo/event.py
@@ -176,10 +176,8 @@ class Event(metaclass=_AutoRegister):
     #_first_raised_by = "The object that generated the event"
     #_last_raised_by = "The object that last relayed the event to the dispatched handler"
 
-    #NOTE: In general I want the no-member error, but in the case of the Event Metaclassing, I'd rather not work out
-    #      how to get the lint parser to work out the nonexistance of members injected by the metaclass, especially
-    #      since setting said variables to "None" at this scope causes other fallout
     #pylint: disable=no-member
+    # Event Metaclass raises "no-member" pylint errors in pylint within this scope.
 
     def __init__(self, **kwargs):
         unset = self._props.copy()

--- a/src/cozmo/event.py
+++ b/src/cozmo/event.py
@@ -138,7 +138,7 @@ class _AutoRegister(type):
                 newattrs[k] = v
                 continue
             if k in props:
-                raise ValueError("Event class %s duplicates property %s defined in superclass" % (self, k))
+                raise ValueError("Event class %s duplicates property %s defined in superclass" % (mcs, k))
             props.add(k)
             newattrs[k] = docstr(v)
         newattrs['_props'] = props
@@ -157,7 +157,7 @@ class _AutoRegister(type):
             raise ValueError("Duplicate event name %s (%s duplicated by %s)"
                     % (name, _full_qual_name(cls), _full_qual_name(registered_events[name])))
         registered_events[name] = cls
-        return super().__init__(name, bases, attrs, **kw)
+        super().__init__(name, bases, attrs, **kw)
 
 
 def _full_qual_name(obj):
@@ -175,6 +175,11 @@ class Event(metaclass=_AutoRegister):
 
     #_first_raised_by = "The object that generated the event"
     #_last_raised_by = "The object that last relayed the event to the dispatched handler"
+
+    #NOTE: In general I want the no-member error, but in the case of the Event Metaclassing, I'd rather not work out
+    #      how to get the lint parser to work out the nonexistance of members injected by the metaclass, especially
+    #      since setting said variables to "None" at this scope causes other fallout
+    #pylint: disable=no-member
 
     def __init__(self, **kwargs):
         unset = self._props.copy()

--- a/src/cozmo/objects.py
+++ b/src/cozmo/objects.py
@@ -241,7 +241,7 @@ class ObservableElement(event.Dispatcher):
 
     def _on_observed(self, image_box, timestamp, changed_fields):
         # Called from subclasses on their corresponding observed messages
-        newly_visible = self._is_visible == False
+        newly_visible = self._is_visible is False
         self._is_visible = True
 
         changed_fields |= {'last_observed_time', 'last_observed_robot_timestamp',

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -1277,7 +1277,7 @@ class Robot(event.Dispatcher):
     def clear_idle_animation(self):
         '''Clears any Idle Animation currently playing on Cozmo'''
 
-        #NOTE: The pylint parser can't really figure out that "Count" is a member that is injected into this namedTuple
+        #NOTE: pylint doesn't identify the member "Count" on this namedTuple which is added at runtime
         #pylint: disable=no-member
         self.set_idle_animation(anim.Triggers.Count)
 

--- a/src/cozmo/robot.py
+++ b/src/cozmo/robot.py
@@ -1276,6 +1276,9 @@ class Robot(event.Dispatcher):
 
     def clear_idle_animation(self):
         '''Clears any Idle Animation currently playing on Cozmo'''
+
+        #NOTE: The pylint parser can't really figure out that "Count" is a member that is injected into this namedTuple
+        #pylint: disable=no-member
         self.set_idle_animation(anim.Triggers.Count)
 
     # Cozmo's Face animation commands

--- a/src/cozmo/run.py
+++ b/src/cozmo/run.py
@@ -344,6 +344,7 @@ class FirstAvailableConnector(DeviceConnector):
     This is the default connector used by ``connect_`` functions.
     '''
     def __init__(self):
+        super().__init__(self, enable_env_vars=False)
         self.tcp = TCPConnector()
         self.ios = IOSConnector()
         self.android = AndroidConnector()

--- a/src/cozmo/run.py
+++ b/src/cozmo/run.py
@@ -94,7 +94,7 @@ class DeviceConnector:
         factory and connect it to the transport, returning a (transport, protocol)
         tuple. See :meth:`asyncio.BaseEventLoop.create_connection`
         '''
-        raise NotImplemented()
+        raise NotImplementedError
 
     def parse_env_vars(self):
         try:

--- a/src/cozmo/run.py
+++ b/src/cozmo/run.py
@@ -87,7 +87,7 @@ class DeviceConnector:
         if enable_env_vars:
             self.parse_env_vars()
 
-    async def connect(self, loop, protocol_factory):
+    async def connect(self, loop, protocol_factory, conn_check):
         '''Connect attempts to open a connection transport to the Cozmo app on a device.
 
         On opening a transport it will create a protocol from the supplied

--- a/src/cozmo/tkview.py
+++ b/src/cozmo/tkview.py
@@ -48,6 +48,9 @@ from . import world
 
 class TkThreadable:
     '''A mixin for adding threadsafe calls to tkinter methods.'''
+    # Pylint seems confused by our mixin calling function that we will assume to be added in the main heirarchy.
+    # @TODO: Maybe there is a cleaner way of doing this?
+    #pylint: disable=no-member
     def __init__(self, *a, **kw):
         self._thread_queue = queue.Queue()
         self.after(50, self._thread_call_dispatch)
@@ -115,6 +118,8 @@ class TkImageViewer(tkinter.Frame, TkThreadable):
             self.handler.disable()
         self.call_threadsafe(self.quit)
 
+    # The base class configure doesn't take an event
+    #pylint: disable=arguments-differ
     def configure(self, event):
         # hack to interrupt feedback loop between image resizing
         # and frame resize detection; there has to be a better solution to this.

--- a/src/cozmo/tkview.py
+++ b/src/cozmo/tkview.py
@@ -48,9 +48,8 @@ from . import world
 
 class TkThreadable:
     '''A mixin for adding threadsafe calls to tkinter methods.'''
-    # Pylint seems confused by our mixin calling function that we will assume to be added in the main heirarchy.
-    # @TODO: Maybe there is a cleaner way of doing this?
     #pylint: disable=no-member
+    # no-member errors are raised in pylint regarding members/methods called but not defined in our mixin.
     def __init__(self, *a, **kw):
         self._thread_queue = queue.Queue()
         self.after(50, self._thread_call_dispatch)

--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -672,7 +672,7 @@ class World(event.Dispatcher):
         """
         msg = _clad_to_engine_iface.DeleteAllCustomObjects()
         self.conn.send_msg(msg)
-        # suppression for _MsgRobotDeletedAllCustomObjects "no-memeber" on pylint
+        # suppression for _MsgRobotDeletedAllCustomObjects "no-member" on pylint
         #pylint: disable=no-member
         await self.wait_for(_clad._MsgRobotDeletedAllCustomObjects)
         self._remove_custom_marker_object_instances()

--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -670,6 +670,7 @@ class World(event.Dispatcher):
         will continue to add new objects if he sees the markers again. To remove
         the definitions for those objects use: :meth:`undefine_all_custom_marker_objects`
         """
+        #pylint: disable=no-member
         msg = _clad_to_engine_iface.DeleteAllCustomObjects()
         self.conn.send_msg(msg)
         await self.wait_for(_clad._MsgRobotDeletedAllCustomObjects)
@@ -684,6 +685,7 @@ class World(event.Dispatcher):
         will continue to add new objects if he sees the markers again. To remove
         the definitions for those objects use: :meth:`undefine_all_custom_marker_objects`
         """
+        #pylint: disable=no-member
         msg = _clad_to_engine_iface.DeleteCustomMarkerObjects()
         self.conn.send_msg(msg)
         await self.wait_for(_clad._MsgRobotDeletedCustomMarkerObjects)
@@ -695,6 +697,7 @@ class World(event.Dispatcher):
         Note: This removes fixed custom objects only, it does NOT remove
         the custom marker object instances or definitions.
         """
+        #pylint: disable=no-member
         msg = _clad_to_engine_iface.DeleteFixedCustomObjects()
         self.conn.send_msg(msg)
         await self.wait_for(_clad._MsgRobotDeletedFixedCustomObjects)
@@ -702,6 +705,7 @@ class World(event.Dispatcher):
 
     async def undefine_all_custom_marker_objects(self):
         """Remove all custom marker object definitions, and any instances of them in the world."""
+        #pylint: disable=no-member
         msg = _clad_to_engine_iface.UndefineAllCustomMarkerObjects()
         self.conn.send_msg(msg)
         await self.wait_for(_clad._MsgRobotDeletedCustomMarkerObjects)
@@ -710,6 +714,7 @@ class World(event.Dispatcher):
         self.custom_objects.clear()
 
     async def _wait_for_defined_custom_object(self, custom_object_archetype):
+        #pylint: disable=no-member
         try:
             msg = await self.wait_for(_clad._MsgDefinedCustomObject, timeout=5)
         except asyncio.TimeoutError as e:
@@ -926,6 +931,7 @@ class World(event.Dispatcher):
         Returns:
             A :class:`cozmo.objects.FixedCustomObject` instance with the specified dimensions and pose.
         '''
+        #pylint: disable=no-member
         # Override the origin of the pose to be the same as the robot's. This will make sure they are in
         # the same space in the engine every time.
         if use_robot_origin:
@@ -979,6 +985,7 @@ class World(event.Dispatcher):
         Returns:
             bool: True if all 3 cubes are now connected.
         """
+        #pylint: disable=no-member
         connected_cubes = list(self.connected_light_cubes)
         num_connected_cubes = len(connected_cubes)
         num_unconnected_cubes = 3 - num_connected_cubes

--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -670,9 +670,11 @@ class World(event.Dispatcher):
         will continue to add new objects if he sees the markers again. To remove
         the definitions for those objects use: :meth:`undefine_all_custom_marker_objects`
         """
-        #pylint: disable=no-member
         msg = _clad_to_engine_iface.DeleteAllCustomObjects()
         self.conn.send_msg(msg)
+        # _MsgRobotDeletedAllCustomObjects isn't strictly a defined class, and as such it confuses the lint pass.  
+        #  I still want no-member errors surfaced in the rest of the file, just not this line
+        #pylint: disable=no-member
         await self.wait_for(_clad._MsgRobotDeletedAllCustomObjects)
         self._remove_custom_marker_object_instances()
         self._remove_fixed_custom_object_instances()
@@ -685,9 +687,9 @@ class World(event.Dispatcher):
         will continue to add new objects if he sees the markers again. To remove
         the definitions for those objects use: :meth:`undefine_all_custom_marker_objects`
         """
-        #pylint: disable=no-member
         msg = _clad_to_engine_iface.DeleteCustomMarkerObjects()
         self.conn.send_msg(msg)
+        #pylint: disable=no-member
         await self.wait_for(_clad._MsgRobotDeletedCustomMarkerObjects)
         self._remove_custom_marker_object_instances()
 
@@ -697,25 +699,25 @@ class World(event.Dispatcher):
         Note: This removes fixed custom objects only, it does NOT remove
         the custom marker object instances or definitions.
         """
-        #pylint: disable=no-member
         msg = _clad_to_engine_iface.DeleteFixedCustomObjects()
         self.conn.send_msg(msg)
+        #pylint: disable=no-member
         await self.wait_for(_clad._MsgRobotDeletedFixedCustomObjects)
         self._remove_fixed_custom_object_instances()
 
     async def undefine_all_custom_marker_objects(self):
         """Remove all custom marker object definitions, and any instances of them in the world."""
-        #pylint: disable=no-member
         msg = _clad_to_engine_iface.UndefineAllCustomMarkerObjects()
         self.conn.send_msg(msg)
+        #pylint: disable=no-member
         await self.wait_for(_clad._MsgRobotDeletedCustomMarkerObjects)
         self._remove_custom_marker_object_instances()
         # Remove all custom object definitions / archetypes
         self.custom_objects.clear()
 
     async def _wait_for_defined_custom_object(self, custom_object_archetype):
-        #pylint: disable=no-member
         try:
+            #pylint: disable=no-member
             msg = await self.wait_for(_clad._MsgDefinedCustomObject, timeout=5)
         except asyncio.TimeoutError as e:
             logger.error("Failed (Timed Out) to define: %s", custom_object_archetype)
@@ -931,7 +933,6 @@ class World(event.Dispatcher):
         Returns:
             A :class:`cozmo.objects.FixedCustomObject` instance with the specified dimensions and pose.
         '''
-        #pylint: disable=no-member
         # Override the origin of the pose to be the same as the robot's. This will make sure they are in
         # the same space in the engine every time.
         if use_robot_origin:
@@ -942,6 +943,7 @@ class World(event.Dispatcher):
         msg = _clad_to_engine_iface.CreateFixedCustomObject(pose=pose.encode_pose(),
                                                             xSize_mm=x_size_mm, ySize_mm=y_size_mm, zSize_mm=z_size_mm)
         self.conn.send_msg(msg)
+        #pylint: disable=no-member
         response = await self.wait_for(_clad._MsgCreatedFixedCustomObject)
         fixed_custom_object = objects.FixedCustomObject(pose, x_size_mm, y_size_mm, z_size_mm, response.msg.objectID)
         self._objects[fixed_custom_object.object_id] = fixed_custom_object
@@ -985,7 +987,6 @@ class World(event.Dispatcher):
         Returns:
             bool: True if all 3 cubes are now connected.
         """
-        #pylint: disable=no-member
         connected_cubes = list(self.connected_light_cubes)
         num_connected_cubes = len(connected_cubes)
         num_unconnected_cubes = 3 - num_connected_cubes
@@ -1004,6 +1005,7 @@ class World(event.Dispatcher):
 
         try:
             for _ in range(num_unconnected_cubes):
+                #pylint: disable=no-member
                 msg = await self.wait_for(_clad._MsgObjectConnectionState, timeout=10)
         except asyncio.TimeoutError as e:
             logger.warning("Failed to connect to all cubes in time!")
@@ -1015,6 +1017,7 @@ class World(event.Dispatcher):
         self.conn._request_connected_objects()
 
         try:
+            #pylint: disable=no-member
             msg = await self.wait_for(_clad._MsgConnectedObjectStates, timeout=5)
         except asyncio.TimeoutError as e:
             logger.warning("Failed to receive connected cube states.")

--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -672,8 +672,7 @@ class World(event.Dispatcher):
         """
         msg = _clad_to_engine_iface.DeleteAllCustomObjects()
         self.conn.send_msg(msg)
-        # _MsgRobotDeletedAllCustomObjects isn't strictly a defined class, and as such it confuses the lint pass.  
-        #  I still want no-member errors surfaced in the rest of the file, just not this line
+        # suppression for _MsgRobotDeletedAllCustomObjects "no-memeber" on pylint
         #pylint: disable=no-member
         await self.wait_for(_clad._MsgRobotDeletedAllCustomObjects)
         self._remove_custom_marker_object_instances()


### PR DESCRIPTION
After reducing down the pylint pass to avoid spamming style-type errors, there were a few remaining things that I wanted either to fix or locally suppress