### PR TITLE
COZMO-7331 Ensure sync connect calls use same loop

### DIFF
--- a/src/cozmo/run.py
+++ b/src/cozmo/run.py
@@ -499,12 +499,12 @@ def _connect_async(f, conn_factory=conn.CozmoConnection, connector=None):
         loop.run_forever()
 
 
+_sync_loop = asyncio.new_event_loop()
 def _connect_sync(f, conn_factory=conn.CozmoConnection, connector=None):
-    loop = asyncio.new_event_loop()
     abort_future = concurrent.futures.Future()
     conn_factory = functools.partial(conn_factory, _sync_abort_future=abort_future)
-    lt = _LoopThread(loop, conn_factory=conn_factory, connector=connector, abort_future=abort_future)
-    loop.set_exception_handler(functools.partial(_sync_exception_handler, abort_future))
+    lt = _LoopThread(_sync_loop, conn_factory=conn_factory, connector=connector, abort_future=abort_future)
+    _sync_loop.set_exception_handler(functools.partial(_sync_exception_handler, abort_future))
 
     coz_conn = lt.start()
 


### PR DESCRIPTION
Creating a new loop for every call to _connect_sync breaks the default
connector instance, which maintains a connection to usbmuxd using the
loop first available to it.  This prevents subsequent calls to connect
from succeeding for synchronous functions.

Instead allocate a loop for synchronous code up front and re-use that
for any subsequent sync calls.

Simple test that will fail prior to this update:

```python
import sys

import cozmo

def run(sdk_conn):
    '''The run method runs once Cozmo is connected.'''
    robot = sdk_conn.wait_for_robot()

if __name__ == '__main__':
    cozmo.setup_basic_logging()
    cozmo.connect(run)
    cozmo.connect(run)
```