### PR TITLE
Handle OpenGL errors on Windows

### DIFF
--- a/src/cozmo/annotate.py
+++ b/src/cozmo/annotate.py
@@ -70,10 +70,14 @@ TOP_RIGHT = TOP | RIGHT
 #: Bottom right position
 BOTTOM_RIGHT = BOTTOM | RIGHT
 
-#: Fastest resampling mode, use nearest pixel
-RESAMPLE_MODE_NEAREST = Image.NEAREST
-#: Slower, but smoother, resampling mode - linear interpolation from 2x2 grid of pixels
-RESAMPLE_MODE_BILINEAR = Image.BILINEAR
+if ImageDraw is not None:
+    #: Fastest resampling mode, use nearest pixel
+    RESAMPLE_MODE_NEAREST = Image.NEAREST
+    #: Slower, but smoother, resampling mode - linear interpolation from 2x2 grid of pixels
+    RESAMPLE_MODE_BILINEAR = Image.BILINEAR
+else:
+    RESAMPLE_MODE_NEAREST = None
+    RESAMPLE_MODE_BILINEAR = None
 
 
 class ImageText:

--- a/src/cozmo/world.py
+++ b/src/cozmo/world.py
@@ -1126,9 +1126,9 @@ class CameraImage:
         Args:
             scale (float): If set then the base image will be scaled by the
                 supplied multiplier.  Cannot be combined with fit_size
-            fit_size (tuple of ints (width, height)):  If set, then scale the
-                image to fit inside the supplied dimensions.  The original
-                aspect ratio will be preserved.  Cannot be combined with scale.
+            fit_size (tuple of int):  If set, then scale the image to fit inside
+                the supplied (width, height) dimensions. The original aspect
+                ratio will be preserved.  Cannot be combined with scale.
             resample_mode (int): The resampling mode to use when scaling the
                 image. Should be either :attr:`~cozmo.annotate.RESAMPLE_MODE_NEAREST`
                 (fast) or :attr:`~cozmo.annotate.RESAMPLE_MODE_BILINEAR` (slower,

--- a/vagrant/setup-vm.sh
+++ b/vagrant/setup-vm.sh
@@ -10,11 +10,14 @@ curl \
 python3-pip \
 expect \
 python3-pil \
-python3-pil.imagetk
+python3-pil.imagetk \
+freeglut3
 pip3 install numpy \
 pillow \
 tweepy \
-flask
+flask \
+pyopengl \
+pyopengl_accelerate
 sudo localectl set-locale LANG="en_US.UTF-8"
 
 echo ">>> Installing Android Command Line Tools"


### PR DESCRIPTION
Catch some errors specific to old/missing GLUT version on Windows
Fix error if Image and ImageDraw were not imported form PIL
Add PyOpenGL and freeglut to Vagrant install