### PR TITLE
Catch import error if importing old Python 2 version of PIL

### DIFF
--- a/src/cozmo/annotate.py
+++ b/src/cozmo/annotate.py
@@ -40,7 +40,8 @@ import functools
 
 try:
     from PIL import Image, ImageDraw
-except ImportError:
+except (ImportError, SyntaxError):
+    # may get SyntaxError if accidentally importing old Python 2 version of PIL
     ImageDraw = None
 
 from . import event


### PR DESCRIPTION
(need to catch `SyntaxError` in addition to `ImportError`)