### PR TITLE
Surface SDK version errors more cleanly

### DIFF
--- a/docs/source/sdk-versions.rst
+++ b/docs/source/sdk-versions.rst
@@ -1,3 +1,5 @@
+.. _sdk-versions:
+
 ####################
 SDK vs. App Versions
 ####################

--- a/src/cozmo/clad_protocol.py
+++ b/src/cozmo/clad_protocol.py
@@ -38,6 +38,7 @@ class CLADProtocol(asyncio.Protocol):
         super().__init__()
 
         self._buf = bytearray()
+        self._abort_connection = False  # abort connection on failed handshake, ignore subsequent messages!
 
     def connection_made(self, transport):
         self.transport = transport
@@ -50,7 +51,7 @@ class CLADProtocol(asyncio.Protocol):
         self._buf.extend(data)
         # pull clad messages out
 
-        while True:
+        while not self._abort_connection:
             msg = self.decode_msg()
             # must compare msg against None, not just "if not msg" as the latter
             # would match against any message with len==0 (which is the case

--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -392,7 +392,8 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
             logger.error(error_message)
 
             exc = exceptions.SDKVersionMismatch("SDK library does not match software running on device",
-                                                sdk_version=cozmoclad.__version__,
+                                                sdk_version=version.__version__,
+                                                sdk_app_version=cozmoclad.__version__,
                                                 app_version=_trimmed_version(msg.buildVersion))
 
             self._abort_connection = True  # Ignore remaining messages - they're not safe to unpack

--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -391,9 +391,9 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
             error_message += line_separator
             logger.error(error_message)
 
-            exc = exceptions.SDKVersionMismatch("SDK library does not match software running on device %s != %s" %
-                                                (cozmoclad.__version__,
-                                                 _trimmed_version(msg.buildVersion)))
+            exc = exceptions.SDKVersionMismatch("SDK library does not match software running on device",
+                                                sdk_version=cozmoclad.__version__,
+                                                app_version=_trimmed_version(msg.buildVersion))
 
             self._abort_connection = True  # Ignore remaining messages - they're not safe to unpack
 

--- a/src/cozmo/conn.py
+++ b/src/cozmo/conn.py
@@ -348,15 +348,14 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
             line_separator = "=" * 80
             error_message = "\n" + line_separator + "\n"
 
+            def _trimmed_version(ver_string):
+                # Trim leading zeros from the version string.
+                trimmed_string = ""
+                for i in ver_string.split("."):
+                    trimmed_string += str(int(i)) + "."
+                return trimmed_string[:-1]  # remove trailing "."
+
             if not build_versions_match:
-
-                def _trimmed_version(ver_string):
-                    # Trim leading zeros from the version string.
-                    trimmed_string = ""
-                    for i in ver_string.split("."):
-                        trimmed_string += str(int(i)) + "."
-                    return trimmed_string[:-1]  # remove trailing "."
-
                 error_message += ("App and SDK versions do not match!\n"
                                   "----------------------------------\n"
                                   "SDK's cozmoclad version: %s\n"
@@ -392,7 +391,12 @@ class CozmoConnection(event.Dispatcher, clad_protocol.CLADProtocol):
             error_message += line_separator
             logger.error(error_message)
 
-            exc = exceptions.SDKVersionMismatch("SDK library does not match software running on device")
+            exc = exceptions.SDKVersionMismatch("SDK library does not match software running on device %s != %s" %
+                                                (cozmoclad.__version__,
+                                                 _trimmed_version(msg.buildVersion)))
+
+            self._abort_connection = True  # Ignore remaining messages - they're not safe to unpack
+
             self.abort(exc)
             return
 

--- a/src/cozmo/exceptions.py
+++ b/src/cozmo/exceptions.py
@@ -51,9 +51,14 @@ class NoDevicesFound(ConnectionError):
 
 class SDKVersionMismatch(ConnectionError):
     '''Raised if the Cozmo SDK version is not compatible with the software running on the device.'''
-    def __init__(self, message, sdk_version, app_version, *args):
-        super().__init__(message, sdk_version, app_version, *args)
+    def __init__(self, message, sdk_version, sdk_app_version, app_version, *args):
+        super().__init__(message, sdk_version, sdk_app_version, app_version, *args)
+        #: str: The SDK version number in Major.Minor.Patch format.
+        #: See :ref:`sdk-versions` for which App version is compatible with each SDK version.
         self.sdk_version = sdk_version
+        #: str: The version of the App that this SDK is compatible with in Major.Minor.Patch format.
+        self.sdk_app_version = sdk_app_version
+        #: str: The version of the App that was detected, and is incompatible, in Major.Minor.Patch format.
         self.app_version = app_version
 
 class NotPickupable(ActionError):

--- a/src/cozmo/exceptions.py
+++ b/src/cozmo/exceptions.py
@@ -51,6 +51,10 @@ class NoDevicesFound(ConnectionError):
 
 class SDKVersionMismatch(ConnectionError):
     '''Raised if the Cozmo SDK version is not compatible with the software running on the device.'''
+    def __init__(self, message, sdk_version, app_version, *args):
+        super().__init__(message, sdk_version, app_version, *args)
+        self.sdk_version = sdk_version
+        self.app_version = app_version
 
 class NotPickupable(ActionError):
     '''Raised if an attempt is made to pick up or place an object that can't be picked up by Cozmo'''

--- a/src/cozmo/run.py
+++ b/src/cozmo/run.py
@@ -277,8 +277,6 @@ class AndroidConnector(DeviceConnector):
                     try:
                         await conn_check(proto)
                     except Exception as e:
-                        if isinstance(e, exceptions.SDKVersionMismatch):
-                            version_mismatch = e
                         logger.debug('Failed connection check: %s', e)
                         raise
 
@@ -286,6 +284,8 @@ class AndroidConnector(DeviceConnector):
                 self._connected.add(serial)
                 _observe_connection_lost(proto, functools.partial(self._disconnect, serial))
                 return transport, proto
+            except exceptions.SDKVersionMismatch as e:
+                version_mismatch = e
             except:
                 pass
             self._remove_forward(serial)


### PR DESCRIPTION
SDKVersionMismatch can now be caught by client code, if they wish to handle it separately.
SDKVersionMismatch exception now includes SDK version along with required and actual App versions.
After detecting the version mismatch, any remaining messages on the connection are ignored (to avoid throwing exceptions when they fail to unpack)
If no valid device connection is found, and an SDKVersionMismatch was detected on any device, then that SDKVersionMismatch exception is returned instead of a general "no devices found" exception.