### PR TITLE
Switch the box used for Vagrant as old one no longer hosted

### DIFF
--- a/docs/source/downloads.rst
+++ b/docs/source/downloads.rst
@@ -18,16 +18,6 @@ GitHub
 
 Clone, fork, or report issues on the `GitHub cozmo-python-sdk repository <https://github.com/anki/cozmo-python-sdk>`_.
 
--------
-Vagrant
--------
-
-Download Vagrant files and follow :ref:`instructions <vagrant-guide>` to install a self-contained VM (Virtual Machine) inside VirtualBox.
-
-:verlink:`macOS/Linux Vagrant bundle <vagrant_bundle_0.0.0.tar.gz>`
-
-:verlink:`Windows Vagrant bundle <vagrant_bundle_0.0.0.zip>`
-
 ----
 
 `Click here to return to the Cozmo Developer website. <http://developer.anki.com>`_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,6 @@ Welcome to the Cozmo SDK!
     install-windows.rst
     install-linux.rst
     adb.rst
-    vagrant.rst
 
 .. toctree::
     :maxdepth: 2

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "boxcutter/ubuntu1604-desktop"  #<--16.04 LTS
+  config.vm.box = "bento/ubuntu-16.04"  #<--16.04 LTS
   config.vm.provider "virtualbox" do |v|
     v.memory = 2028
     v.cpus = 2


### PR DESCRIPTION
boxcutter no longer host boxes, and nobody seems to host a desktop box anymore so switched to an available server box.
Removed vagrant from documentation tabs, and removed the links from the download - the underlying files and the vagrant.html page still exist, so if anyone really needs it or was relying on it they can find it, but it's no longer user-facing so new users won't be confused by it being there (especially now that it's a non-desktop Linux image, so is less user-friendly).