### PR TITLE
add a throw_error flag to run_program to throw error rather than exit

### DIFF
--- a/src/cozmo/run.py
+++ b/src/cozmo/run.py
@@ -781,7 +781,7 @@ def run_program(f, use_viewer=False, conn_factory=conn.CozmoConnection,
                 connector=None, force_viewer_on_top=False,
                 deprecated_filter="default", use_3d_viewer=False,
                 show_viewer_controls=True,
-                throw_error=False):
+                exit_on_connection_error=True):
     '''Connect to Cozmo and run the provided program/function f.
 
     Args:
@@ -810,6 +810,8 @@ def run_program(f, use_viewer=False, conn_factory=conn.CozmoConnection,
             `use_viewer` are set then the 2D camera view will render in an OpenGL
             window instead of a TkView window.
         show_viewer_controls (bool): Specifies whether to draw controls on the view.
+        exit_on_connection_error (bool): Specify whether the program should exit on
+            connection error or should an error be raised. Default to true.
     '''
     setup_basic_logging(deprecated_filter=deprecated_filter)
 
@@ -848,8 +850,8 @@ def run_program(f, use_viewer=False, conn_factory=conn.CozmoConnection,
     except KeyboardInterrupt:
         logger.info('Exit requested by user')
     except exceptions.ConnectionError as e:
-        if throw_error:
-            logger.error("A connection error occurred: %s" % e)
-            raise e
-        else:
+        if exit_on_connection_error:
             sys.exit("A connection error occurred: %s" % e)
+        else:
+            logger.error("A connection error occurred: %s" % e)
+            raise

--- a/src/cozmo/run.py
+++ b/src/cozmo/run.py
@@ -780,7 +780,8 @@ def setup_basic_logging(general_log_level=None, protocol_log_level=None,
 def run_program(f, use_viewer=False, conn_factory=conn.CozmoConnection,
                 connector=None, force_viewer_on_top=False,
                 deprecated_filter="default", use_3d_viewer=False,
-                show_viewer_controls=True):
+                show_viewer_controls=True,
+                throw_error=False):
     '''Connect to Cozmo and run the provided program/function f.
 
     Args:
@@ -847,4 +848,8 @@ def run_program(f, use_viewer=False, conn_factory=conn.CozmoConnection,
     except KeyboardInterrupt:
         logger.info('Exit requested by user')
     except exceptions.ConnectionError as e:
-        sys.exit("A connection error occurred: %s" % e)
+        if throw_error:
+            logger.error("A connection error occurred: %s" % e)
+            raise e
+        else:
+            sys.exit("A connection error occurred: %s" % e)


### PR DESCRIPTION
I started building a REPL starting from the cli.py program in the sdk examples.

I have the need to catch connexion error to display some message in a more frendly way than logs.
Here is a patch to enable this =)