### PR TITLE
Update SDK to work with Python 3.12+

### DIFF
--- a/src/cozmo/event.py
+++ b/src/cozmo/event.py
@@ -485,7 +485,7 @@ class Dispatcher(base.Base):
 
         self.add_event_handler(event, f)
         if timeout:
-             return await asyncio.wait_for(f, timeout, loop=self._loop)
+             return await asyncio.wait_for(f, timeout)
         return await f
 
 

--- a/src/cozmo/run.py
+++ b/src/cozmo/run.py
@@ -361,7 +361,7 @@ class FirstAvailableConnector(DeviceConnector):
 
     async def _do_connect(self, connector,loop, protocol_factory, conn_check):
         connect = connector.connect(loop, protocol_factory, conn_check)
-        result = await asyncio.gather(connect, loop=loop, return_exceptions=True)
+        result = await asyncio.gather(connect, return_exceptions=True)
         return result[0]
 
     async def connect(self, loop, protocol_factory, conn_check):


### PR DESCRIPTION
Updated two `asyncio` function calls to work with Python 3.12 and above.